### PR TITLE
Fix Mongo GridFS Implementation

### DIFF
--- a/slimeworldmanager-plugin/src/main/java/com/grinderwolf/swm/plugin/loaders/MongoLoader.java
+++ b/slimeworldmanager-plugin/src/main/java/com/grinderwolf/swm/plugin/loaders/MongoLoader.java
@@ -66,7 +66,7 @@ public class MongoLoader implements SlimeLoader {
                 mongoCollection.updateOne(Filters.eq("name", worldName), Updates.set("locked", true));
             }
 
-            GridFSBucket bucket = GridFSBuckets.create(mongoDatabase, collection + "_files");
+            GridFSBucket bucket = GridFSBuckets.create(mongoDatabase, collection);
             ByteArrayOutputStream stream = new ByteArrayOutputStream();
             bucket.downloadToStream(worldName, stream);
 
@@ -93,7 +93,7 @@ public class MongoLoader implements SlimeLoader {
     public void saveWorld(String worldName, byte[] serializedWorld, boolean lock) throws IOException {
         try {
             MongoDatabase mongoDatabase = client.getDatabase(database);
-            GridFSBucket bucket = GridFSBuckets.create(mongoDatabase, collection + "_files");
+            GridFSBucket bucket = GridFSBuckets.create(mongoDatabase, collection);
             GridFSFile oldFile = bucket.find(Filters.eq("filename", worldName)).first();
 
             if (oldFile != null) {
@@ -152,7 +152,7 @@ public class MongoLoader implements SlimeLoader {
     public void deleteWorld(String worldName) throws IOException, UnknownWorldException {
         try {
             MongoDatabase mongoDatabase = client.getDatabase(database);
-            GridFSBucket bucket = GridFSBuckets.create(mongoDatabase, collection + "_files");
+            GridFSBucket bucket = GridFSBuckets.create(mongoDatabase, collection);
             GridFSFile file = bucket.find(Filters.eq("filename", worldName)).first();
 
             if (file == null) {


### PR DESCRIPTION
This pull request fixes issues an issue which I came across revolving the Mongo implementation. With the current implementation of GridFS it's setup to fail if you use mongofiles to import. 

Mongo Version: Mongo v4.0.11
mongofiles Command Used:
`
mongofiles -h=REDACTED -u=REDACTED-p=REDACTED --authenticationDatabase=REDACTED -d=worlds --prefix=worlds put world
`

Bare in mind I also had to remove the .slime file type when actually putting it into my database in-order for the Mongo implementation to load it properly as it'll search only for file name "world" rather than "world.slime" which could potentially be seen as another issue as other users may end up putting the world file as "worldname.slime" into their Mongo  database.

The import will always created the collections:
worlds.chunks
worlds.files

Which then following that I manually created the "worlds" collection and manually created the following document:
`
{
    "name" : "world",
    "locked" : false
}
`

To my understanding with the GridFSBuckets#create doesn't require the "_files" or ".files" suffix to be defined and will work if the collection is just directly passed as it auto handles the suffixing in the usage. In this PR I went ahead and removed the forced suffixing which then allows the world to properly be loaded. 