### PR TITLE
Skip null tile entities

### DIFF
--- a/slimeworldmanager-nms-v1_10_R1/src/main/java/com/grinderwolf/swm/nms/v1_10_R1/Converter.java
+++ b/slimeworldmanager-nms-v1_10_R1/src/main/java/com/grinderwolf/swm/nms/v1_10_R1/Converter.java
@@ -36,6 +36,8 @@ import net.minecraft.server.v1_10_R1.NBTTagLong;
 import net.minecraft.server.v1_10_R1.NBTTagShort;
 import net.minecraft.server.v1_10_R1.NBTTagString;
 import net.minecraft.server.v1_10_R1.TileEntity;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
@@ -43,6 +45,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class Converter {
+
+    private static final Logger LOGGER = LogManager.getLogger("SWM Converter");
 
     static net.minecraft.server.v1_10_R1.NibbleArray convertArray(NibbleArray array) {
         return new net.minecraft.server.v1_10_R1.NibbleArray(array.getBacking());
@@ -53,38 +57,45 @@ public class Converter {
     }
 
     static NBTBase convertTag(Tag tag) {
-        switch (tag.getType()) {
-            case TAG_BYTE:
-                return new NBTTagByte(((ByteTag) tag).getValue());
-            case TAG_SHORT:
-                return new NBTTagShort(((ShortTag) tag).getValue());
-            case TAG_INT:
-                return new NBTTagInt(((IntTag) tag).getValue());
-            case TAG_LONG:
-                return new NBTTagLong(((LongTag) tag).getValue());
-            case TAG_FLOAT:
-                return new NBTTagFloat(((FloatTag) tag).getValue());
-            case TAG_DOUBLE:
-                return new NBTTagDouble(((DoubleTag) tag).getValue());
-            case TAG_BYTE_ARRAY:
-                return new NBTTagByteArray(((ByteArrayTag) tag).getValue());
-            case TAG_STRING:
-                return new NBTTagString(((StringTag) tag).getValue());
-            case TAG_INT_ARRAY:
-                return new NBTTagIntArray(((IntArrayTag) tag).getValue());
-            case TAG_LIST:
-                NBTTagList list = new NBTTagList();
-                ((ListTag<?>) tag).getValue().stream().map(Converter::convertTag).forEach(list::add);
+        try {
+            switch (tag.getType()) {
+                case TAG_BYTE:
+                    return new NBTTagByte(((ByteTag) tag).getValue());
+                case TAG_SHORT:
+                    return new NBTTagShort(((ShortTag) tag).getValue());
+                case TAG_INT:
+                    return new NBTTagInt(((IntTag) tag).getValue());
+                case TAG_LONG:
+                    return new NBTTagLong(((LongTag) tag).getValue());
+                case TAG_FLOAT:
+                    return new NBTTagFloat(((FloatTag) tag).getValue());
+                case TAG_DOUBLE:
+                    return new NBTTagDouble(((DoubleTag) tag).getValue());
+                case TAG_BYTE_ARRAY:
+                    return new NBTTagByteArray(((ByteArrayTag) tag).getValue());
+                case TAG_STRING:
+                    return new NBTTagString(((StringTag) tag).getValue());
+                case TAG_INT_ARRAY:
+                    return new NBTTagIntArray(((IntArrayTag) tag).getValue());
+                case TAG_LIST:
+                    NBTTagList list = new NBTTagList();
+                    ((ListTag<?>) tag).getValue().stream().map(Converter::convertTag).forEach(list::add);
 
-                return list;
-            case TAG_COMPOUND:
-                NBTTagCompound compound = new NBTTagCompound();
+                    return list;
+                case TAG_COMPOUND:
+                    NBTTagCompound compound = new NBTTagCompound();
 
-                ((CompoundTag) tag).getValue().forEach((key, value) -> compound.set(key, convertTag(value)));
+                    ((CompoundTag) tag).getValue().forEach((key, value) -> compound.set(key, convertTag(value)));
 
-                return compound;
-            default:
-                throw new IllegalArgumentException("Invalid tag type " + tag.getType().name());
+                    return compound;
+                default:
+                    throw new IllegalArgumentException("Invalid tag type " + tag.getType().name());
+            }
+        } catch (Exception ex) {
+            LOGGER.error("Failed to convert NBT object:");
+            LOGGER.error(tag.toString());
+
+            throw ex;
         }
     }
 

--- a/slimeworldmanager-nms-v1_10_R1/src/main/java/com/grinderwolf/swm/nms/v1_10_R1/CustomChunkLoader.java
+++ b/slimeworldmanager-nms-v1_10_R1/src/main/java/com/grinderwolf/swm/nms/v1_10_R1/CustomChunkLoader.java
@@ -21,6 +21,7 @@ import org.apache.logging.log4j.Logger;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.List;
+import java.util.Optional;
 
 @RequiredArgsConstructor
 public class CustomChunkLoader implements IChunkLoader {
@@ -94,11 +95,16 @@ public class CustomChunkLoader implements IChunkLoader {
 
         if (tileEntities != null) {
             for (CompoundTag tag : tileEntities) {
-                TileEntity entity = TileEntity.a(nmsWorld, (NBTTagCompound) Converter.convertTag(tag));
+                Optional<String> type = tag.getStringValue("id");
 
-                if (entity != null) {
-                    nmsChunk.a(entity);
-                    loadedEntities++;
+                // Sometimes null tile entities are saved
+                if (type.isPresent()) {
+                    TileEntity entity = TileEntity.a(nmsWorld, (NBTTagCompound) Converter.convertTag(tag));
+
+                    if (entity != null) {
+                        nmsChunk.a(entity);
+                        loadedEntities++;
+                    }
                 }
             }
         }

--- a/slimeworldmanager-nms-v1_11_R1/src/main/java/com/grinderwolf/swm/nms/v1_11_R1/Converter.java
+++ b/slimeworldmanager-nms-v1_11_R1/src/main/java/com/grinderwolf/swm/nms/v1_11_R1/Converter.java
@@ -36,6 +36,8 @@ import net.minecraft.server.v1_11_R1.NBTTagLong;
 import net.minecraft.server.v1_11_R1.NBTTagShort;
 import net.minecraft.server.v1_11_R1.NBTTagString;
 import net.minecraft.server.v1_11_R1.TileEntity;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
@@ -43,6 +45,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class Converter {
+
+    private static final Logger LOGGER = LogManager.getLogger("SWM Converter");
 
     static net.minecraft.server.v1_11_R1.NibbleArray convertArray(NibbleArray array) {
         return new net.minecraft.server.v1_11_R1.NibbleArray(array.getBacking());
@@ -53,38 +57,45 @@ public class Converter {
     }
 
     static NBTBase convertTag(Tag tag) {
-        switch (tag.getType()) {
-            case TAG_BYTE:
-                return new NBTTagByte(((ByteTag) tag).getValue());
-            case TAG_SHORT:
-                return new NBTTagShort(((ShortTag) tag).getValue());
-            case TAG_INT:
-                return new NBTTagInt(((IntTag) tag).getValue());
-            case TAG_LONG:
-                return new NBTTagLong(((LongTag) tag).getValue());
-            case TAG_FLOAT:
-                return new NBTTagFloat(((FloatTag) tag).getValue());
-            case TAG_DOUBLE:
-                return new NBTTagDouble(((DoubleTag) tag).getValue());
-            case TAG_BYTE_ARRAY:
-                return new NBTTagByteArray(((ByteArrayTag) tag).getValue());
-            case TAG_STRING:
-                return new NBTTagString(((StringTag) tag).getValue());
-            case TAG_INT_ARRAY:
-                return new NBTTagIntArray(((IntArrayTag) tag).getValue());
-            case TAG_LIST:
-                NBTTagList list = new NBTTagList();
-                ((ListTag<?>) tag).getValue().stream().map(Converter::convertTag).forEach(list::add);
+        try {
+            switch (tag.getType()) {
+                case TAG_BYTE:
+                    return new NBTTagByte(((ByteTag) tag).getValue());
+                case TAG_SHORT:
+                    return new NBTTagShort(((ShortTag) tag).getValue());
+                case TAG_INT:
+                    return new NBTTagInt(((IntTag) tag).getValue());
+                case TAG_LONG:
+                    return new NBTTagLong(((LongTag) tag).getValue());
+                case TAG_FLOAT:
+                    return new NBTTagFloat(((FloatTag) tag).getValue());
+                case TAG_DOUBLE:
+                    return new NBTTagDouble(((DoubleTag) tag).getValue());
+                case TAG_BYTE_ARRAY:
+                    return new NBTTagByteArray(((ByteArrayTag) tag).getValue());
+                case TAG_STRING:
+                    return new NBTTagString(((StringTag) tag).getValue());
+                case TAG_INT_ARRAY:
+                    return new NBTTagIntArray(((IntArrayTag) tag).getValue());
+                case TAG_LIST:
+                    NBTTagList list = new NBTTagList();
+                    ((ListTag<?>) tag).getValue().stream().map(Converter::convertTag).forEach(list::add);
 
-                return list;
-            case TAG_COMPOUND:
-                NBTTagCompound compound = new NBTTagCompound();
+                    return list;
+                case TAG_COMPOUND:
+                    NBTTagCompound compound = new NBTTagCompound();
 
-                ((CompoundTag) tag).getValue().forEach((key, value) -> compound.set(key, convertTag(value)));
+                    ((CompoundTag) tag).getValue().forEach((key, value) -> compound.set(key, convertTag(value)));
 
-                return compound;
-            default:
-                throw new IllegalArgumentException("Invalid tag type " + tag.getType().name());
+                    return compound;
+                default:
+                    throw new IllegalArgumentException("Invalid tag type " + tag.getType().name());
+            }
+        } catch (Exception ex) {
+            LOGGER.error("Failed to convert NBT object:");
+            LOGGER.error(tag.toString());
+
+            throw ex;
         }
     }
 

--- a/slimeworldmanager-nms-v1_11_R1/src/main/java/com/grinderwolf/swm/nms/v1_11_R1/CustomChunkLoader.java
+++ b/slimeworldmanager-nms-v1_11_R1/src/main/java/com/grinderwolf/swm/nms/v1_11_R1/CustomChunkLoader.java
@@ -21,6 +21,7 @@ import org.apache.logging.log4j.Logger;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.List;
+import java.util.Optional;
 
 @RequiredArgsConstructor
 public class CustomChunkLoader implements IChunkLoader {
@@ -94,11 +95,16 @@ public class CustomChunkLoader implements IChunkLoader {
 
         if (tileEntities != null) {
             for (CompoundTag tag : tileEntities) {
-                TileEntity entity = TileEntity.a(nmsWorld, (NBTTagCompound) Converter.convertTag(tag));
+                Optional<String> type = tag.getStringValue("id");
 
-                if (entity != null) {
-                    nmsChunk.a(entity);
-                    loadedEntities++;
+                // Sometimes null tile entities are saved
+                if (type.isPresent()) {
+                    TileEntity entity = TileEntity.a(nmsWorld, (NBTTagCompound) Converter.convertTag(tag));
+
+                    if (entity != null) {
+                        nmsChunk.a(entity);
+                        loadedEntities++;
+                    }
                 }
             }
         }

--- a/slimeworldmanager-nms-v1_12_R1/src/main/java/com/grinderwolf/swm/nms/v1_12_R1/Converter.java
+++ b/slimeworldmanager-nms-v1_12_R1/src/main/java/com/grinderwolf/swm/nms/v1_12_R1/Converter.java
@@ -36,6 +36,8 @@ import net.minecraft.server.v1_12_R1.NBTTagLong;
 import net.minecraft.server.v1_12_R1.NBTTagShort;
 import net.minecraft.server.v1_12_R1.NBTTagString;
 import net.minecraft.server.v1_12_R1.TileEntity;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
@@ -43,6 +45,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class Converter {
+
+    private static final Logger LOGGER = LogManager.getLogger("SWM Converter");
 
     static net.minecraft.server.v1_12_R1.NibbleArray convertArray(NibbleArray array) {
         return new net.minecraft.server.v1_12_R1.NibbleArray(array.getBacking());
@@ -53,38 +57,45 @@ public class Converter {
     }
 
     static NBTBase convertTag(Tag tag) {
-        switch (tag.getType()) {
-            case TAG_BYTE:
-                return new NBTTagByte(((ByteTag) tag).getValue());
-            case TAG_SHORT:
-                return new NBTTagShort(((ShortTag) tag).getValue());
-            case TAG_INT:
-                return new NBTTagInt(((IntTag) tag).getValue());
-            case TAG_LONG:
-                return new NBTTagLong(((LongTag) tag).getValue());
-            case TAG_FLOAT:
-                return new NBTTagFloat(((FloatTag) tag).getValue());
-            case TAG_DOUBLE:
-                return new NBTTagDouble(((DoubleTag) tag).getValue());
-            case TAG_BYTE_ARRAY:
-                return new NBTTagByteArray(((ByteArrayTag) tag).getValue());
-            case TAG_STRING:
-                return new NBTTagString(((StringTag) tag).getValue());
-            case TAG_INT_ARRAY:
-                return new NBTTagIntArray(((IntArrayTag) tag).getValue());
-            case TAG_LIST:
-                NBTTagList list = new NBTTagList();
-                ((ListTag<?>) tag).getValue().stream().map(Converter::convertTag).forEach(list::add);
+        try {
+            switch (tag.getType()) {
+                case TAG_BYTE:
+                    return new NBTTagByte(((ByteTag) tag).getValue());
+                case TAG_SHORT:
+                    return new NBTTagShort(((ShortTag) tag).getValue());
+                case TAG_INT:
+                    return new NBTTagInt(((IntTag) tag).getValue());
+                case TAG_LONG:
+                    return new NBTTagLong(((LongTag) tag).getValue());
+                case TAG_FLOAT:
+                    return new NBTTagFloat(((FloatTag) tag).getValue());
+                case TAG_DOUBLE:
+                    return new NBTTagDouble(((DoubleTag) tag).getValue());
+                case TAG_BYTE_ARRAY:
+                    return new NBTTagByteArray(((ByteArrayTag) tag).getValue());
+                case TAG_STRING:
+                    return new NBTTagString(((StringTag) tag).getValue());
+                case TAG_INT_ARRAY:
+                    return new NBTTagIntArray(((IntArrayTag) tag).getValue());
+                case TAG_LIST:
+                    NBTTagList list = new NBTTagList();
+                    ((ListTag<?>) tag).getValue().stream().map(Converter::convertTag).forEach(list::add);
 
-                return list;
-            case TAG_COMPOUND:
-                NBTTagCompound compound = new NBTTagCompound();
+                    return list;
+                case TAG_COMPOUND:
+                    NBTTagCompound compound = new NBTTagCompound();
 
-                ((CompoundTag) tag).getValue().forEach((key, value) -> compound.set(key, convertTag(value)));
+                    ((CompoundTag) tag).getValue().forEach((key, value) -> compound.set(key, convertTag(value)));
 
-                return compound;
-            default:
-                throw new IllegalArgumentException("Invalid tag type " + tag.getType().name());
+                    return compound;
+                default:
+                    throw new IllegalArgumentException("Invalid tag type " + tag.getType().name());
+            }
+        } catch (Exception ex) {
+            LOGGER.error("Failed to convert NBT object:");
+            LOGGER.error(tag.toString());
+
+            throw ex;
         }
     }
 

--- a/slimeworldmanager-nms-v1_12_R1/src/main/java/com/grinderwolf/swm/nms/v1_12_R1/CustomChunkLoader.java
+++ b/slimeworldmanager-nms-v1_12_R1/src/main/java/com/grinderwolf/swm/nms/v1_12_R1/CustomChunkLoader.java
@@ -21,6 +21,7 @@ import org.apache.logging.log4j.Logger;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.List;
+import java.util.Optional;
 
 @RequiredArgsConstructor
 public class CustomChunkLoader implements IChunkLoader {
@@ -94,11 +95,16 @@ public class CustomChunkLoader implements IChunkLoader {
 
         if (tileEntities != null) {
             for (CompoundTag tag : tileEntities) {
-                TileEntity entity = TileEntity.create(nmsWorld, (NBTTagCompound) Converter.convertTag(tag));
+                Optional<String> type = tag.getStringValue("id");
 
-                if (entity != null) {
-                    nmsChunk.a(entity);
-                    loadedEntities++;
+                // Sometimes null tile entities are saved
+                if (type.isPresent()) {
+                    TileEntity entity = TileEntity.create(nmsWorld, (NBTTagCompound) Converter.convertTag(tag));
+
+                    if (entity != null) {
+                        nmsChunk.a(entity);
+                        loadedEntities++;
+                    }
                 }
             }
         }

--- a/slimeworldmanager-nms-v1_13_R1/src/main/java/com/grinderwolf/swm/nms/v1_13_R1/Converter.java
+++ b/slimeworldmanager-nms-v1_13_R1/src/main/java/com/grinderwolf/swm/nms/v1_13_R1/Converter.java
@@ -40,11 +40,15 @@ import net.minecraft.server.v1_13_R1.NBTTagLongArray;
 import net.minecraft.server.v1_13_R1.NBTTagShort;
 import net.minecraft.server.v1_13_R1.NBTTagString;
 import net.minecraft.server.v1_13_R1.TileEntity;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
 import java.util.List;
 
 public class Converter {
+
+    private static final Logger LOGGER = LogManager.getLogger("SWM Converter");
 
     static net.minecraft.server.v1_13_R1.NibbleArray convertArray(NibbleArray array) {
         return new net.minecraft.server.v1_13_R1.NibbleArray(array.getBacking());
@@ -55,40 +59,47 @@ public class Converter {
     }
 
     static NBTBase convertTag(Tag tag) {
-        switch (tag.getType()) {
-            case TAG_BYTE:
-                return new NBTTagByte(((ByteTag) tag).getValue());
-            case TAG_SHORT:
-                return new NBTTagShort(((ShortTag) tag).getValue());
-            case TAG_INT:
-                return new NBTTagInt(((IntTag) tag).getValue());
-            case TAG_LONG:
-                return new NBTTagLong(((LongTag) tag).getValue());
-            case TAG_FLOAT:
-                return new NBTTagFloat(((FloatTag) tag).getValue());
-            case TAG_DOUBLE:
-                return new NBTTagDouble(((DoubleTag) tag).getValue());
-            case TAG_BYTE_ARRAY:
-                return new NBTTagByteArray(((ByteArrayTag) tag).getValue());
-            case TAG_STRING:
-                return new NBTTagString(((StringTag) tag).getValue());
-            case TAG_LIST:
-                NBTTagList list = new NBTTagList();
-                ((ListTag<?>) tag).getValue().stream().map(Converter::convertTag).forEach(list::add);
+        try {
+            switch (tag.getType()) {
+                case TAG_BYTE:
+                    return new NBTTagByte(((ByteTag) tag).getValue());
+                case TAG_SHORT:
+                    return new NBTTagShort(((ShortTag) tag).getValue());
+                case TAG_INT:
+                    return new NBTTagInt(((IntTag) tag).getValue());
+                case TAG_LONG:
+                    return new NBTTagLong(((LongTag) tag).getValue());
+                case TAG_FLOAT:
+                    return new NBTTagFloat(((FloatTag) tag).getValue());
+                case TAG_DOUBLE:
+                    return new NBTTagDouble(((DoubleTag) tag).getValue());
+                case TAG_BYTE_ARRAY:
+                    return new NBTTagByteArray(((ByteArrayTag) tag).getValue());
+                case TAG_STRING:
+                    return new NBTTagString(((StringTag) tag).getValue());
+                case TAG_LIST:
+                    NBTTagList list = new NBTTagList();
+                    ((ListTag<?>) tag).getValue().stream().map(Converter::convertTag).forEach(list::add);
 
-                return list;
-            case TAG_COMPOUND:
-                NBTTagCompound compound = new NBTTagCompound();
+                    return list;
+                case TAG_COMPOUND:
+                    NBTTagCompound compound = new NBTTagCompound();
 
-                ((CompoundTag) tag).getValue().forEach((key, value) -> compound.set(key, convertTag(value)));
+                    ((CompoundTag) tag).getValue().forEach((key, value) -> compound.set(key, convertTag(value)));
 
-                return compound;
-            case TAG_INT_ARRAY:
-                return new NBTTagIntArray(((IntArrayTag) tag).getValue());
-            case TAG_LONG_ARRAY:
-                return new NBTTagLongArray(((LongArrayTag) tag).getValue());
-            default:
-                throw new IllegalArgumentException("Invalid tag type " + tag.getType().name());
+                    return compound;
+                case TAG_INT_ARRAY:
+                    return new NBTTagIntArray(((IntArrayTag) tag).getValue());
+                case TAG_LONG_ARRAY:
+                    return new NBTTagLongArray(((LongArrayTag) tag).getValue());
+                default:
+                    throw new IllegalArgumentException("Invalid tag type " + tag.getType().name());
+            }
+        } catch (Exception ex) {
+            LOGGER.error("Failed to convert NBT object:");
+            LOGGER.error(tag.toString());
+
+            throw ex;
         }
     }
 
@@ -114,8 +125,7 @@ public class Converter {
                 List<Tag> list = new ArrayList<>();
                 NBTTagList originalList = ((NBTTagList) base);
 
-                for (int i = 0; i < originalList.size(); i++) {
-                    NBTBase entry = originalList.get(i);
+                for (NBTBase entry : originalList) {
                     list.add(convertTag("", entry));
                 }
 

--- a/slimeworldmanager-nms-v1_13_R1/src/main/java/com/grinderwolf/swm/nms/v1_13_R1/CustomChunkLoader.java
+++ b/slimeworldmanager-nms-v1_13_R1/src/main/java/com/grinderwolf/swm/nms/v1_13_R1/CustomChunkLoader.java
@@ -35,6 +35,7 @@ import org.apache.logging.log4j.Logger;
 
 import javax.annotation.Nullable;
 import java.util.List;
+import java.util.Optional;
 import java.util.function.Consumer;
 
 @RequiredArgsConstructor
@@ -181,11 +182,16 @@ public class CustomChunkLoader implements IChunkLoader {
 
         if (tileEntities != null) {
             for (CompoundTag tag : tileEntities) {
-                TileEntity entity = TileEntity.create((NBTTagCompound) Converter.convertTag(tag));
+                Optional<String> type = tag.getStringValue("id");
 
-                if (entity != null) {
-                    nmsChunk.a(entity);
-                    loadedEntities++;
+                // Sometimes null tile entities are saved
+                if (type.isPresent()) {
+                    TileEntity entity = TileEntity.create((NBTTagCompound) Converter.convertTag(tag));
+
+                    if (entity != null) {
+                        nmsChunk.a(entity);
+                        loadedEntities++;
+                    }
                 }
             }
         }

--- a/slimeworldmanager-nms-v1_13_R2/src/main/java/com/grinderwolf/swm/nms/v1_13_R2/Converter.java
+++ b/slimeworldmanager-nms-v1_13_R2/src/main/java/com/grinderwolf/swm/nms/v1_13_R2/Converter.java
@@ -41,11 +41,15 @@ import net.minecraft.server.v1_13_R2.NBTTagLongArray;
 import net.minecraft.server.v1_13_R2.NBTTagShort;
 import net.minecraft.server.v1_13_R2.NBTTagString;
 import net.minecraft.server.v1_13_R2.TileEntity;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
 import java.util.List;
 
 public class Converter {
+
+    private static final Logger LOGGER = LogManager.getLogger("SWM Converter");
 
     static net.minecraft.server.v1_13_R2.NibbleArray convertArray(NibbleArray array) {
         return new net.minecraft.server.v1_13_R2.NibbleArray(array.getBacking());
@@ -56,40 +60,47 @@ public class Converter {
     }
 
     static NBTBase convertTag(Tag tag) {
-        switch (tag.getType()) {
-            case TAG_BYTE:
-                return new NBTTagByte(((ByteTag) tag).getValue());
-            case TAG_SHORT:
-                return new NBTTagShort(((ShortTag) tag).getValue());
-            case TAG_INT:
-                return new NBTTagInt(((IntTag) tag).getValue());
-            case TAG_LONG:
-                return new NBTTagLong(((LongTag) tag).getValue());
-            case TAG_FLOAT:
-                return new NBTTagFloat(((FloatTag) tag).getValue());
-            case TAG_DOUBLE:
-                return new NBTTagDouble(((DoubleTag) tag).getValue());
-            case TAG_BYTE_ARRAY:
-                return new NBTTagByteArray(((ByteArrayTag) tag).getValue());
-            case TAG_STRING:
-                return new NBTTagString(((StringTag) tag).getValue());
-            case TAG_LIST:
-                NBTTagList list = new NBTTagList();
-                ((ListTag<?>) tag).getValue().stream().map(Converter::convertTag).forEach(list::add);
+        try {
+            switch (tag.getType()) {
+                case TAG_BYTE:
+                    return new NBTTagByte(((ByteTag) tag).getValue());
+                case TAG_SHORT:
+                    return new NBTTagShort(((ShortTag) tag).getValue());
+                case TAG_INT:
+                    return new NBTTagInt(((IntTag) tag).getValue());
+                case TAG_LONG:
+                    return new NBTTagLong(((LongTag) tag).getValue());
+                case TAG_FLOAT:
+                    return new NBTTagFloat(((FloatTag) tag).getValue());
+                case TAG_DOUBLE:
+                    return new NBTTagDouble(((DoubleTag) tag).getValue());
+                case TAG_BYTE_ARRAY:
+                    return new NBTTagByteArray(((ByteArrayTag) tag).getValue());
+                case TAG_STRING:
+                    return new NBTTagString(((StringTag) tag).getValue());
+                case TAG_LIST:
+                    NBTTagList list = new NBTTagList();
+                    ((ListTag<?>) tag).getValue().stream().map(Converter::convertTag).forEach(list::add);
 
-                return list;
-            case TAG_COMPOUND:
-                NBTTagCompound compound = new NBTTagCompound();
+                    return list;
+                case TAG_COMPOUND:
+                    NBTTagCompound compound = new NBTTagCompound();
 
-                ((CompoundTag) tag).getValue().forEach((key, value) -> compound.set(key, convertTag(value)));
+                    ((CompoundTag) tag).getValue().forEach((key, value) -> compound.set(key, convertTag(value)));
 
-                return compound;
-            case TAG_INT_ARRAY:
-                return new NBTTagIntArray(((IntArrayTag) tag).getValue());
-            case TAG_LONG_ARRAY:
-                return new NBTTagLongArray(((LongArrayTag) tag).getValue());
-            default:
-                throw new IllegalArgumentException("Invalid tag type " + tag.getType().name());
+                    return compound;
+                case TAG_INT_ARRAY:
+                    return new NBTTagIntArray(((IntArrayTag) tag).getValue());
+                case TAG_LONG_ARRAY:
+                    return new NBTTagLongArray(((LongArrayTag) tag).getValue());
+                default:
+                    throw new IllegalArgumentException("Invalid tag type " + tag.getType().name());
+            }
+        } catch (Exception ex) {
+            LOGGER.error("Failed to convert NBT object:");
+            LOGGER.error(tag.toString());
+
+            throw ex;
         }
     }
 
@@ -115,8 +126,7 @@ public class Converter {
                 List<Tag> list = new ArrayList<>();
                 NBTTagList originalList = ((NBTTagList) base);
 
-                for (int i = 0; i < originalList.size(); i++) {
-                    NBTBase entry = originalList.get(i);
+                for (NBTBase entry : originalList) {
                     list.add(convertTag("", entry));
                 }
 

--- a/slimeworldmanager-nms-v1_13_R2/src/main/java/com/grinderwolf/swm/nms/v1_13_R2/CustomChunkLoader.java
+++ b/slimeworldmanager-nms-v1_13_R2/src/main/java/com/grinderwolf/swm/nms/v1_13_R2/CustomChunkLoader.java
@@ -39,6 +39,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import javax.annotation.Nullable;
+import java.util.Optional;
 import java.util.function.Consumer;
 
 @RequiredArgsConstructor
@@ -197,7 +198,12 @@ public class CustomChunkLoader implements IChunkLoader {
                 NBTTagList tileEntities = new NBTTagList();
 
                 for (CompoundTag tileEntityTag : chunk.getTileEntities()) {
-                    tileEntities.add(Converter.convertTag(tileEntityTag));
+                    Optional<String> type = tileEntityTag.getStringValue("id");
+
+                    // Sometimes null tile entities are saved
+                    if (type.isPresent()) {
+                        tileEntities.add(Converter.convertTag(tileEntityTag));
+                    }
                 }
 
                 levelCompound.set("TileEntities", tileEntities);

--- a/slimeworldmanager-nms-v1_14_R1/src/main/java/com/grinderwolf/swm/nms/v1_14_R1/Converter.java
+++ b/slimeworldmanager-nms-v1_14_R1/src/main/java/com/grinderwolf/swm/nms/v1_14_R1/Converter.java
@@ -44,11 +44,15 @@ import net.minecraft.server.v1_14_R1.NBTTagShort;
 import net.minecraft.server.v1_14_R1.NBTTagString;
 import net.minecraft.server.v1_14_R1.SectionPosition;
 import net.minecraft.server.v1_14_R1.TileEntity;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
 import java.util.List;
 
 public class Converter {
+
+    private static final Logger LOGGER = LogManager.getLogger("SWM Converter");
 
     static net.minecraft.server.v1_14_R1.NibbleArray convertArray(NibbleArray array) {
         return new net.minecraft.server.v1_14_R1.NibbleArray(array.getBacking());
@@ -63,40 +67,47 @@ public class Converter {
     }
 
     static NBTBase convertTag(Tag tag) {
-        switch (tag.getType()) {
-            case TAG_BYTE:
-                return new NBTTagByte(((ByteTag) tag).getValue());
-            case TAG_SHORT:
-                return new NBTTagShort(((ShortTag) tag).getValue());
-            case TAG_INT:
-                return new NBTTagInt(((IntTag) tag).getValue());
-            case TAG_LONG:
-                return new NBTTagLong(((LongTag) tag).getValue());
-            case TAG_FLOAT:
-                return new NBTTagFloat(((FloatTag) tag).getValue());
-            case TAG_DOUBLE:
-                return new NBTTagDouble(((DoubleTag) tag).getValue());
-            case TAG_BYTE_ARRAY:
-                return new NBTTagByteArray(((ByteArrayTag) tag).getValue());
-            case TAG_STRING:
-                return new NBTTagString(((StringTag) tag).getValue());
-            case TAG_LIST:
-                NBTTagList list = new NBTTagList();
-                ((ListTag<?>) tag).getValue().stream().map(Converter::convertTag).forEach(list::add);
+        try {
+            switch (tag.getType()) {
+                case TAG_BYTE:
+                    return new NBTTagByte(((ByteTag) tag).getValue());
+                case TAG_SHORT:
+                    return new NBTTagShort(((ShortTag) tag).getValue());
+                case TAG_INT:
+                    return new NBTTagInt(((IntTag) tag).getValue());
+                case TAG_LONG:
+                    return new NBTTagLong(((LongTag) tag).getValue());
+                case TAG_FLOAT:
+                    return new NBTTagFloat(((FloatTag) tag).getValue());
+                case TAG_DOUBLE:
+                    return new NBTTagDouble(((DoubleTag) tag).getValue());
+                case TAG_BYTE_ARRAY:
+                    return new NBTTagByteArray(((ByteArrayTag) tag).getValue());
+                case TAG_STRING:
+                    return new NBTTagString(((StringTag) tag).getValue());
+                case TAG_LIST:
+                    NBTTagList list = new NBTTagList();
+                    ((ListTag<?>) tag).getValue().stream().map(Converter::convertTag).forEach(list::add);
 
-                return list;
-            case TAG_COMPOUND:
-                NBTTagCompound compound = new NBTTagCompound();
+                    return list;
+                case TAG_COMPOUND:
+                    NBTTagCompound compound = new NBTTagCompound();
 
-                ((CompoundTag) tag).getValue().forEach((key, value) -> compound.set(key, convertTag(value)));
+                    ((CompoundTag) tag).getValue().forEach((key, value) -> compound.set(key, convertTag(value)));
 
-                return compound;
-            case TAG_INT_ARRAY:
-                return new NBTTagIntArray(((IntArrayTag) tag).getValue());
-            case TAG_LONG_ARRAY:
-                return new NBTTagLongArray(((LongArrayTag) tag).getValue());
-            default:
-                throw new IllegalArgumentException("Invalid tag type " + tag.getType().name());
+                    return compound;
+                case TAG_INT_ARRAY:
+                    return new NBTTagIntArray(((IntArrayTag) tag).getValue());
+                case TAG_LONG_ARRAY:
+                    return new NBTTagLongArray(((LongArrayTag) tag).getValue());
+                default:
+                    throw new IllegalArgumentException("Invalid tag type " + tag.getType().name());
+            }
+        } catch (Exception ex) {
+            LOGGER.error("Failed to convert NBT object:");
+            LOGGER.error(tag.toString());
+
+            throw ex;
         }
     }
 
@@ -122,8 +133,7 @@ public class Converter {
                 List<Tag> list = new ArrayList<>();
                 NBTTagList originalList = ((NBTTagList) base);
 
-                for (int i = 0; i < originalList.size(); i++) {
-                    NBTBase entry = originalList.get(i);
+                for (NBTBase entry : originalList) {
                     list.add(convertTag("", entry));
                 }
 

--- a/slimeworldmanager-nms-v1_14_R1/src/main/java/com/grinderwolf/swm/nms/v1_14_R1/CraftCLSMBridge.java
+++ b/slimeworldmanager-nms-v1_14_R1/src/main/java/com/grinderwolf/swm/nms/v1_14_R1/CraftCLSMBridge.java
@@ -39,6 +39,7 @@ import org.apache.logging.log4j.Logger;
 import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.function.Consumer;
 
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
@@ -147,11 +148,16 @@ public class CraftCLSMBridge implements CLSMBridge {
 
             if (tileEntities != null) {
                 for (CompoundTag tag : tileEntities) {
-                    TileEntity entity = TileEntity.create((NBTTagCompound) Converter.convertTag(tag));
+                    Optional<String> type = tag.getStringValue("id");
 
-                    if (entity != null) {
-                        nmsChunk.a(entity);
-                        loadedEntities++;
+                    // Sometimes null tile entities are saved
+                    if (type.isPresent()) {
+                        TileEntity entity = TileEntity.create((NBTTagCompound) Converter.convertTag(tag));
+
+                        if (entity != null) {
+                            nmsChunk.a(entity);
+                            loadedEntities++;
+                        }
                     }
                 }
             }

--- a/slimeworldmanager-nms-v1_8_R3/src/main/java/com/grinderwolf/swm/nms/v1_8_R3/Converter.java
+++ b/slimeworldmanager-nms-v1_8_R3/src/main/java/com/grinderwolf/swm/nms/v1_8_R3/Converter.java
@@ -7,6 +7,8 @@ import com.grinderwolf.swm.api.utils.NibbleArray;
 import com.grinderwolf.swm.nms.CraftSlimeChunk;
 import com.grinderwolf.swm.nms.CraftSlimeChunkSection;
 import net.minecraft.server.v1_8_R3.*;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
@@ -14,6 +16,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class Converter {
+
+    private static final Logger LOGGER = LogManager.getLogger("SWM Converter");
 
     static net.minecraft.server.v1_8_R3.NibbleArray convertArray(NibbleArray array) {
         return new net.minecraft.server.v1_8_R3.NibbleArray(array.getBacking());
@@ -24,38 +28,45 @@ public class Converter {
     }
 
     static NBTBase convertTag(Tag tag) {
-        switch (tag.getType()) {
-            case TAG_BYTE:
-                return new NBTTagByte(((ByteTag) tag).getValue());
-            case TAG_SHORT:
-                return new NBTTagShort(((ShortTag) tag).getValue());
-            case TAG_INT:
-                return new NBTTagInt(((IntTag) tag).getValue());
-            case TAG_LONG:
-                return new NBTTagLong(((LongTag) tag).getValue());
-            case TAG_FLOAT:
-                return new NBTTagFloat(((FloatTag) tag).getValue());
-            case TAG_DOUBLE:
-                return new NBTTagDouble(((DoubleTag) tag).getValue());
-            case TAG_BYTE_ARRAY:
-                return new NBTTagByteArray(((ByteArrayTag) tag).getValue());
-            case TAG_STRING:
-                return new NBTTagString(((StringTag) tag).getValue());
-            case TAG_INT_ARRAY:
-                return new NBTTagIntArray(((IntArrayTag) tag).getValue());
-            case TAG_LIST:
-                NBTTagList list = new NBTTagList();
-                ((ListTag<?>) tag).getValue().stream().map(Converter::convertTag).forEach(list::add);
+        try {
+            switch (tag.getType()) {
+                case TAG_BYTE:
+                    return new NBTTagByte(((ByteTag) tag).getValue());
+                case TAG_SHORT:
+                    return new NBTTagShort(((ShortTag) tag).getValue());
+                case TAG_INT:
+                    return new NBTTagInt(((IntTag) tag).getValue());
+                case TAG_LONG:
+                    return new NBTTagLong(((LongTag) tag).getValue());
+                case TAG_FLOAT:
+                    return new NBTTagFloat(((FloatTag) tag).getValue());
+                case TAG_DOUBLE:
+                    return new NBTTagDouble(((DoubleTag) tag).getValue());
+                case TAG_BYTE_ARRAY:
+                    return new NBTTagByteArray(((ByteArrayTag) tag).getValue());
+                case TAG_STRING:
+                    return new NBTTagString(((StringTag) tag).getValue());
+                case TAG_INT_ARRAY:
+                    return new NBTTagIntArray(((IntArrayTag) tag).getValue());
+                case TAG_LIST:
+                    NBTTagList list = new NBTTagList();
+                    ((ListTag<?>) tag).getValue().stream().map(Converter::convertTag).forEach(list::add);
 
-                return list;
-            case TAG_COMPOUND:
-                NBTTagCompound compound = new NBTTagCompound();
+                    return list;
+                case TAG_COMPOUND:
+                    NBTTagCompound compound = new NBTTagCompound();
 
-                ((CompoundTag) tag).getValue().forEach((key, value) -> compound.set(key, convertTag(value)));
+                    ((CompoundTag) tag).getValue().forEach((key, value) -> compound.set(key, convertTag(value)));
 
-                return compound;
-            default:
-                throw new IllegalArgumentException("Invalid tag type " + tag.getType().name());
+                    return compound;
+                default:
+                    throw new IllegalArgumentException("Invalid tag type " + tag.getType().name());
+            }
+        } catch (Exception ex) {
+            LOGGER.error("Failed to convert NBT object:");
+            LOGGER.error(tag.toString());
+
+            throw ex;
         }
     }
 

--- a/slimeworldmanager-nms-v1_8_R3/src/main/java/com/grinderwolf/swm/nms/v1_8_R3/CustomChunkLoader.java
+++ b/slimeworldmanager-nms-v1_8_R3/src/main/java/com/grinderwolf/swm/nms/v1_8_R3/CustomChunkLoader.java
@@ -21,6 +21,7 @@ import org.apache.logging.log4j.Logger;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.List;
+import java.util.Optional;
 
 @RequiredArgsConstructor
 public class CustomChunkLoader implements IChunkLoader {
@@ -118,11 +119,16 @@ public class CustomChunkLoader implements IChunkLoader {
 
         if (tileEntities != null) {
             for (CompoundTag tag : tileEntities) {
-                TileEntity entity = TileEntity.c((NBTTagCompound) Converter.convertTag(tag));
+                Optional<String> type = tag.getStringValue("id");
 
-                if (entity != null) {
-                    nmsChunk.a(entity);
-                    loadedEntities++;
+                // Sometimes null tile entities are saved
+                if (type.isPresent()) {
+                    TileEntity entity = TileEntity.c((NBTTagCompound) Converter.convertTag(tag));
+
+                    if (entity != null) {
+                        nmsChunk.a(entity);
+                        loadedEntities++;
+                    }
                 }
             }
         }

--- a/slimeworldmanager-nms-v1_9_R1/src/main/java/com/grinderwolf/swm/nms/v1_9_R1/Converter.java
+++ b/slimeworldmanager-nms-v1_9_R1/src/main/java/com/grinderwolf/swm/nms/v1_9_R1/Converter.java
@@ -36,6 +36,8 @@ import net.minecraft.server.v1_9_R1.NBTTagLong;
 import net.minecraft.server.v1_9_R1.NBTTagShort;
 import net.minecraft.server.v1_9_R1.NBTTagString;
 import net.minecraft.server.v1_9_R1.TileEntity;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
@@ -43,6 +45,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class Converter {
+
+    private static final Logger LOGGER = LogManager.getLogger("SWM Converter");
 
     static net.minecraft.server.v1_9_R1.NibbleArray convertArray(NibbleArray array) {
         return new net.minecraft.server.v1_9_R1.NibbleArray(array.getBacking());
@@ -53,38 +57,45 @@ public class Converter {
     }
 
     static NBTBase convertTag(Tag tag) {
-        switch (tag.getType()) {
-            case TAG_BYTE:
-                return new NBTTagByte(((ByteTag) tag).getValue());
-            case TAG_SHORT:
-                return new NBTTagShort(((ShortTag) tag).getValue());
-            case TAG_INT:
-                return new NBTTagInt(((IntTag) tag).getValue());
-            case TAG_LONG:
-                return new NBTTagLong(((LongTag) tag).getValue());
-            case TAG_FLOAT:
-                return new NBTTagFloat(((FloatTag) tag).getValue());
-            case TAG_DOUBLE:
-                return new NBTTagDouble(((DoubleTag) tag).getValue());
-            case TAG_BYTE_ARRAY:
-                return new NBTTagByteArray(((ByteArrayTag) tag).getValue());
-            case TAG_STRING:
-                return new NBTTagString(((StringTag) tag).getValue());
-            case TAG_INT_ARRAY:
-                return new NBTTagIntArray(((IntArrayTag) tag).getValue());
-            case TAG_LIST:
-                NBTTagList list = new NBTTagList();
-                ((ListTag<?>) tag).getValue().stream().map(Converter::convertTag).forEach(list::add);
+        try {
+            switch (tag.getType()) {
+                case TAG_BYTE:
+                    return new NBTTagByte(((ByteTag) tag).getValue());
+                case TAG_SHORT:
+                    return new NBTTagShort(((ShortTag) tag).getValue());
+                case TAG_INT:
+                    return new NBTTagInt(((IntTag) tag).getValue());
+                case TAG_LONG:
+                    return new NBTTagLong(((LongTag) tag).getValue());
+                case TAG_FLOAT:
+                    return new NBTTagFloat(((FloatTag) tag).getValue());
+                case TAG_DOUBLE:
+                    return new NBTTagDouble(((DoubleTag) tag).getValue());
+                case TAG_BYTE_ARRAY:
+                    return new NBTTagByteArray(((ByteArrayTag) tag).getValue());
+                case TAG_STRING:
+                    return new NBTTagString(((StringTag) tag).getValue());
+                case TAG_INT_ARRAY:
+                    return new NBTTagIntArray(((IntArrayTag) tag).getValue());
+                case TAG_LIST:
+                    NBTTagList list = new NBTTagList();
+                    ((ListTag<?>) tag).getValue().stream().map(Converter::convertTag).forEach(list::add);
 
-                return list;
-            case TAG_COMPOUND:
-                NBTTagCompound compound = new NBTTagCompound();
+                    return list;
+                case TAG_COMPOUND:
+                    NBTTagCompound compound = new NBTTagCompound();
 
-                ((CompoundTag) tag).getValue().forEach((key, value) -> compound.set(key, convertTag(value)));
+                    ((CompoundTag) tag).getValue().forEach((key, value) -> compound.set(key, convertTag(value)));
 
-                return compound;
-            default:
-                throw new IllegalArgumentException("Invalid tag type " + tag.getType().name());
+                    return compound;
+                default:
+                    throw new IllegalArgumentException("Invalid tag type " + tag.getType().name());
+            }
+        } catch (Exception ex) {
+            LOGGER.error("Failed to convert NBT object:");
+            LOGGER.error(tag.toString());
+
+            throw ex;
         }
     }
 

--- a/slimeworldmanager-nms-v1_9_R1/src/main/java/com/grinderwolf/swm/nms/v1_9_R1/CustomChunkLoader.java
+++ b/slimeworldmanager-nms-v1_9_R1/src/main/java/com/grinderwolf/swm/nms/v1_9_R1/CustomChunkLoader.java
@@ -21,6 +21,7 @@ import org.apache.logging.log4j.Logger;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.List;
+import java.util.Optional;
 
 @RequiredArgsConstructor
 public class CustomChunkLoader implements IChunkLoader {
@@ -94,11 +95,16 @@ public class CustomChunkLoader implements IChunkLoader {
 
         if (tileEntities != null) {
             for (CompoundTag tag : tileEntities) {
-                TileEntity entity = TileEntity.a(nmsWorld.getMinecraftServer(), (NBTTagCompound) Converter.convertTag(tag));
+                Optional<String> type = tag.getStringValue("id");
 
-                if (entity != null) {
-                    nmsChunk.a(entity);
-                    loadedEntities++;
+                // Sometimes null tile entities are saved
+                if (type.isPresent()) {
+                    TileEntity entity = TileEntity.a(nmsWorld.getMinecraftServer(), (NBTTagCompound) Converter.convertTag(tag));
+
+                    if (entity != null) {
+                        nmsChunk.a(entity);
+                        loadedEntities++;
+                    }
                 }
             }
         }

--- a/slimeworldmanager-nms-v1_9_R2/src/main/java/com/grinderwolf/swm/nms/v1_9_R2/Converter.java
+++ b/slimeworldmanager-nms-v1_9_R2/src/main/java/com/grinderwolf/swm/nms/v1_9_R2/Converter.java
@@ -36,6 +36,8 @@ import net.minecraft.server.v1_9_R2.NBTTagLong;
 import net.minecraft.server.v1_9_R2.NBTTagShort;
 import net.minecraft.server.v1_9_R2.NBTTagString;
 import net.minecraft.server.v1_9_R2.TileEntity;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
@@ -43,6 +45,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class Converter {
+
+    private static final Logger LOGGER = LogManager.getLogger("SWM Converter");
 
     static net.minecraft.server.v1_9_R2.NibbleArray convertArray(NibbleArray array) {
         return new net.minecraft.server.v1_9_R2.NibbleArray(array.getBacking());
@@ -53,38 +57,45 @@ public class Converter {
     }
 
     static NBTBase convertTag(Tag tag) {
-        switch (tag.getType()) {
-            case TAG_BYTE:
-                return new NBTTagByte(((ByteTag) tag).getValue());
-            case TAG_SHORT:
-                return new NBTTagShort(((ShortTag) tag).getValue());
-            case TAG_INT:
-                return new NBTTagInt(((IntTag) tag).getValue());
-            case TAG_LONG:
-                return new NBTTagLong(((LongTag) tag).getValue());
-            case TAG_FLOAT:
-                return new NBTTagFloat(((FloatTag) tag).getValue());
-            case TAG_DOUBLE:
-                return new NBTTagDouble(((DoubleTag) tag).getValue());
-            case TAG_BYTE_ARRAY:
-                return new NBTTagByteArray(((ByteArrayTag) tag).getValue());
-            case TAG_STRING:
-                return new NBTTagString(((StringTag) tag).getValue());
-            case TAG_INT_ARRAY:
-                return new NBTTagIntArray(((IntArrayTag) tag).getValue());
-            case TAG_LIST:
-                NBTTagList list = new NBTTagList();
-                ((ListTag<?>) tag).getValue().stream().map(Converter::convertTag).forEach(list::add);
+        try {
+            switch (tag.getType()) {
+                case TAG_BYTE:
+                    return new NBTTagByte(((ByteTag) tag).getValue());
+                case TAG_SHORT:
+                    return new NBTTagShort(((ShortTag) tag).getValue());
+                case TAG_INT:
+                    return new NBTTagInt(((IntTag) tag).getValue());
+                case TAG_LONG:
+                    return new NBTTagLong(((LongTag) tag).getValue());
+                case TAG_FLOAT:
+                    return new NBTTagFloat(((FloatTag) tag).getValue());
+                case TAG_DOUBLE:
+                    return new NBTTagDouble(((DoubleTag) tag).getValue());
+                case TAG_BYTE_ARRAY:
+                    return new NBTTagByteArray(((ByteArrayTag) tag).getValue());
+                case TAG_STRING:
+                    return new NBTTagString(((StringTag) tag).getValue());
+                case TAG_INT_ARRAY:
+                    return new NBTTagIntArray(((IntArrayTag) tag).getValue());
+                case TAG_LIST:
+                    NBTTagList list = new NBTTagList();
+                    ((ListTag<?>) tag).getValue().stream().map(Converter::convertTag).forEach(list::add);
 
-                return list;
-            case TAG_COMPOUND:
-                NBTTagCompound compound = new NBTTagCompound();
+                    return list;
+                case TAG_COMPOUND:
+                    NBTTagCompound compound = new NBTTagCompound();
 
-                ((CompoundTag) tag).getValue().forEach((key, value) -> compound.set(key, convertTag(value)));
+                    ((CompoundTag) tag).getValue().forEach((key, value) -> compound.set(key, convertTag(value)));
 
-                return compound;
-            default:
-                throw new IllegalArgumentException("Invalid tag type " + tag.getType().name());
+                    return compound;
+                default:
+                    throw new IllegalArgumentException("Invalid tag type " + tag.getType().name());
+            }
+        }  catch (Exception ex) {
+            LOGGER.error("Failed to convert NBT object:");
+            LOGGER.error(tag.toString());
+
+            throw ex;
         }
     }
 

--- a/slimeworldmanager-nms-v1_9_R2/src/main/java/com/grinderwolf/swm/nms/v1_9_R2/CustomChunkLoader.java
+++ b/slimeworldmanager-nms-v1_9_R2/src/main/java/com/grinderwolf/swm/nms/v1_9_R2/CustomChunkLoader.java
@@ -21,6 +21,7 @@ import org.apache.logging.log4j.Logger;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.List;
+import java.util.Optional;
 
 @RequiredArgsConstructor
 public class CustomChunkLoader implements IChunkLoader {
@@ -94,11 +95,16 @@ public class CustomChunkLoader implements IChunkLoader {
 
         if (tileEntities != null) {
             for (CompoundTag tag : tileEntities) {
-                TileEntity entity = TileEntity.c((NBTTagCompound) Converter.convertTag(tag));
+                Optional<String> type = tag.getStringValue("id");
 
-                if (entity != null) {
-                    nmsChunk.a(entity);
-                    loadedEntities++;
+                // Sometimes null tile entities are saved
+                if (type.isPresent()) {
+                    TileEntity entity = TileEntity.c((NBTTagCompound) Converter.convertTag(tag));
+
+                    if (entity != null) {
+                        nmsChunk.a(entity);
+                        loadedEntities++;
+                    }
                 }
             }
         }

--- a/slimeworldmanager-plugin/src/main/java/com/grinderwolf/swm/plugin/upgrade/v1_13/v1_13WorldUpgrade.java
+++ b/slimeworldmanager-plugin/src/main/java/com/grinderwolf/swm/plugin/upgrade/v1_13/v1_13WorldUpgrade.java
@@ -37,6 +37,7 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -271,6 +272,8 @@ public class v1_13WorldUpgrade implements Upgrade {
                                             if (createAction == null) {
                                                 throw new IllegalStateException("No create action was specified for block " + name + " but no tile entity was found");
                                             }
+
+                                            Objects.requireNonNull(createAction.getName(), "Tile entity type cannot be null (" + name + ")");
 
                                             CompoundMap tileMap = new CompoundMap();
                                             tileMap.put("id", new StringTag("id", "minecraft:" + createAction.getName()));


### PR DESCRIPTION
For some reason, tile entities with type `null` are saved sometimes, causing the chunk loader to throw an NPE when loading a chunk. This PR skips those tile entities.

Fixes issue #39 