### PR TITLE
Datapacks need to be loaded even if the default world is a slime world.

### DIFF
--- a/slimeworldmanager-classmodifier/src/main/resources/v1_13_R1/MinecraftServer_loadWorlds.txt
+++ b/slimeworldmanager-classmodifier/src/main/resources/v1_13_R1/MinecraftServer_loadWorlds.txt
@@ -49,6 +49,7 @@
                 } else {
                     org.spigotmc.SpigotConfig.disableStatSaving = true;
                     org.spigotmc.SpigotConfig.disableAdvancementSaving = true;
+                    $0.a(new java.io.File(""), world.getWorldData());
                 }
                 
                 $0.server.scoreboardManager = new org.bukkit.craftbukkit.v1_13_R1.scoreboard.CraftScoreboardManager($0, world.getScoreboard());

--- a/slimeworldmanager-classmodifier/src/main/resources/v1_13_R2/MinecraftServer_loadWorlds.txt
+++ b/slimeworldmanager-classmodifier/src/main/resources/v1_13_R2/MinecraftServer_loadWorlds.txt
@@ -48,6 +48,7 @@
                 } else {
                     org.spigotmc.SpigotConfig.disableStatSaving = true;
                     org.spigotmc.SpigotConfig.disableAdvancementSaving = true;
+                    $0.a(new java.io.File(""), world.getWorldData());
                 }
                 
                 $0.server.scoreboardManager = new org.bukkit.craftbukkit.v1_13_R2.scoreboard.CraftScoreboardManager($0, world.getScoreboard());

--- a/slimeworldmanager-classmodifier/src/main/resources/v1_14_R1/MinecraftServer_loadWorlds.txt
+++ b/slimeworldmanager-classmodifier/src/main/resources/v1_14_R1/MinecraftServer_loadWorlds.txt
@@ -48,6 +48,7 @@
                 } else {
                     org.spigotmc.SpigotConfig.disableStatSaving = true;
                     org.spigotmc.SpigotConfig.disableAdvancementSaving = true;
+                    $0.a(new java.io.File(""), world.getWorldData());
                 }
                 
                 $0.initializeScoreboards(world.getWorldPersistentData());


### PR DESCRIPTION
If no datapacks are loaded, fluids start behaving in a weird way (and probably more stuff too). This fixes #51 