### PR TITLE
Add beds to the 1.11 world upgrader

### DIFF
--- a/slimeworldmanager-plugin/src/main/java/com/grinderwolf/swm/plugin/upgrade/v1_11/v1_11WorldUpgrade.java
+++ b/slimeworldmanager-plugin/src/main/java/com/grinderwolf/swm/plugin/upgrade/v1_11/v1_11WorldUpgrade.java
@@ -38,10 +38,14 @@ public class v1_11WorldUpgrade implements Upgrade {
         rename("Structure", "minecraft:structure_block");
         rename("EndGateway", "minecraft:end_gateway");
         rename("Control", "minecraft:command_block");
+        rename(null, "minecraft:bed"); // Patch for issue s#62
     }
 
     private static void rename(String oldName, String newName) {
-        oldToNewMap.put(oldName, newName);
+        if (oldName != null) {
+            oldToNewMap.put(oldName, newName);
+        }
+
         newToOldMap.put(newName, oldName);
     }
 


### PR DESCRIPTION
When updating to the latest SRF version, world version is deduced based on how blocks are stored on chunks, so it's always either v1 (1.8) or v4 (1.13). Because of this, some worlds might be upgraded unnecessarily, as the world version is not correct. This change adds the new bed tile entity so v5 (and older) 1.11 worlds can be loaded.

This fixes issue #62.