### PR TITLE
It's "locked", not "lock".

### DIFF
--- a/slimeworldmanager-plugin/src/main/java/com/grinderwolf/swm/plugin/loaders/MongoLoader.java
+++ b/slimeworldmanager-plugin/src/main/java/com/grinderwolf/swm/plugin/loaders/MongoLoader.java
@@ -142,7 +142,7 @@ public class MongoLoader implements SlimeLoader {
 
             if (worldDoc == null) {
                 mongoCollection.insertOne(new Document().append("name", worldName).append("locked", lock));
-            } else if (!worldDoc.getBoolean("lock") && lock) {
+            } else if (!worldDoc.getBoolean("locked") && lock) {
                 mongoCollection.updateOne(Filters.eq("name", worldName), Updates.set("locked", true));
             }
         } catch (MongoException ex) {


### PR DESCRIPTION
This fixes issue #72.