### PR TITLE
Fixed SWM obtaining wrong dimension ids.

### DIFF
--- a/slimeworldmanager-nms-v1_10_R1/src/main/java/com/grinderwolf/swm/nms/v1_10_R1/v1_10_R1SlimeNMS.java
+++ b/slimeworldmanager-nms-v1_10_R1/src/main/java/com/grinderwolf/swm/nms/v1_10_R1/v1_10_R1SlimeNMS.java
@@ -81,12 +81,18 @@ public class v1_10_R1SlimeNMS implements SlimeNMS {
         MinecraftServer mcServer = MinecraftServer.getServer();
 
         int dimension = CraftWorld.CUSTOM_DIMENSION_OFFSET + mcServer.worlds.size();
+        boolean used = false;
 
-        for (WorldServer server : mcServer.worlds) {
-            if (server.dimension == dimension) {
-                dimension++;
+        do {
+            for (WorldServer server : mcServer.worlds) {
+                used = server.dimension == dimension;
+
+                if (used) {
+                    dimension++;
+                    break;
+                }
             }
-        }
+        } while (used);
 
         return new CustomWorldServer((CraftSlimeWorld) world, dataManager, dimension);
     }

--- a/slimeworldmanager-nms-v1_11_R1/src/main/java/com/grinderwolf/swm/nms/v1_11_R1/v1_11_R1SlimeNMS.java
+++ b/slimeworldmanager-nms-v1_11_R1/src/main/java/com/grinderwolf/swm/nms/v1_11_R1/v1_11_R1SlimeNMS.java
@@ -81,12 +81,18 @@ public class v1_11_R1SlimeNMS implements SlimeNMS {
         MinecraftServer mcServer = MinecraftServer.getServer();
 
         int dimension = CraftWorld.CUSTOM_DIMENSION_OFFSET + mcServer.worlds.size();
+        boolean used = false;
 
-        for (WorldServer server : mcServer.worlds) {
-            if (server.dimension == dimension) {
-                dimension++;
+        do {
+            for (WorldServer server : mcServer.worlds) {
+                used = server.dimension == dimension;
+
+                if (used) {
+                    dimension++;
+                    break;
+                }
             }
-        }
+        } while (used);
 
         return new CustomWorldServer((CraftSlimeWorld) world, dataManager, dimension);
     }

--- a/slimeworldmanager-nms-v1_12_R1/src/main/java/com/grinderwolf/swm/nms/v1_12_R1/v1_12_R1SlimeNMS.java
+++ b/slimeworldmanager-nms-v1_12_R1/src/main/java/com/grinderwolf/swm/nms/v1_12_R1/v1_12_R1SlimeNMS.java
@@ -81,12 +81,18 @@ public class v1_12_R1SlimeNMS implements SlimeNMS {
         MinecraftServer mcServer = MinecraftServer.getServer();
 
         int dimension = CraftWorld.CUSTOM_DIMENSION_OFFSET + mcServer.worlds.size();
+        boolean used = false;
 
-        for (WorldServer server : mcServer.worlds) {
-            if (server.dimension == dimension) {
-                dimension++;
+        do {
+            for (WorldServer server : mcServer.worlds) {
+                used = server.dimension == dimension;
+
+                if (used) {
+                    dimension++;
+                    break;
+                }
             }
-        }
+        } while (used);
 
         return new CustomWorldServer((CraftSlimeWorld) world, dataManager, dimension).b();
     }

--- a/slimeworldmanager-nms-v1_13_R1/src/main/java/com/grinderwolf/swm/nms/v1_13_R1/v1_13_R1SlimeNMS.java
+++ b/slimeworldmanager-nms-v1_13_R1/src/main/java/com/grinderwolf/swm/nms/v1_13_R1/v1_13_R1SlimeNMS.java
@@ -73,12 +73,18 @@ public class v1_13_R1SlimeNMS implements SlimeNMS {
         MinecraftServer mcServer = MinecraftServer.getServer();
 
         int dimension = CraftWorld.CUSTOM_DIMENSION_OFFSET + mcServer.worlds.size();
+        boolean used = false;
 
-        for (WorldServer server : mcServer.worlds) {
-            if (server.dimension == dimension) {
-                dimension++;
+        do {
+            for (WorldServer server : mcServer.worlds) {
+                used = server.dimension == dimension;
+
+                if (used) {
+                    dimension++;
+                    break;
+                }
             }
-        }
+        } while (used);
 
         return new CustomWorldServer((CraftSlimeWorld) world, dataManager, dimension).b();
     }

--- a/slimeworldmanager-nms-v1_14_R1/src/main/java/com/grinderwolf/swm/nms/v1_14_R1/v1_14_R1SlimeNMS.java
+++ b/slimeworldmanager-nms-v1_14_R1/src/main/java/com/grinderwolf/swm/nms/v1_14_R1/v1_14_R1SlimeNMS.java
@@ -74,12 +74,18 @@ public class v1_14_R1SlimeNMS implements SlimeNMS {
         MinecraftServer mcServer = MinecraftServer.getServer();
 
         int dimension = CraftWorld.CUSTOM_DIMENSION_OFFSET + mcServer.worldServer.size();
+        boolean used = false;
 
-        for (WorldServer server : mcServer.getWorlds()) {
-            if (server.getWorldProvider().getDimensionManager().getDimensionID() + 1 == dimension) { // getDimensionID() returns the dimension - 1
-                dimension++;
+        do {
+            for (WorldServer server : mcServer.getWorlds()) {
+                used = server.getWorldProvider().getDimensionManager().getDimensionID() + 1 == dimension;
+
+                if (used) { // getDimensionID() returns the dimension - 1
+                    dimension++;
+                    break;
+                }
             }
-        }
+        } while (used);
 
         World.Environment env = World.Environment.valueOf(world.getPropertyMap().getString(SlimeProperties.ENVIRONMENT).toUpperCase());
 

--- a/slimeworldmanager-nms-v1_8_R3/src/main/java/com/grinderwolf/swm/nms/v1_8_R3/v1_8_R3SlimeNMS.java
+++ b/slimeworldmanager-nms-v1_8_R3/src/main/java/com/grinderwolf/swm/nms/v1_8_R3/v1_8_R3SlimeNMS.java
@@ -68,12 +68,18 @@ public class v1_8_R3SlimeNMS implements SlimeNMS {
         MinecraftServer mcServer = MinecraftServer.getServer();
 
         int dimension = CraftWorld.CUSTOM_DIMENSION_OFFSET + mcServer.worlds.size();
+        boolean used = false;
 
-        for (WorldServer server : mcServer.worlds) {
-            if (server.dimension == dimension) {
-                dimension++;
+        do {
+            for (WorldServer server : mcServer.worlds) {
+                used = server.dimension == dimension;
+
+                if (used) {
+                    dimension++;
+                    break;
+                }
             }
-        }
+        } while (used);
 
         return new CustomWorldServer((CraftSlimeWorld) world, dataManager, dimension);
     }

--- a/slimeworldmanager-nms-v1_9_R1/src/main/java/com/grinderwolf/swm/nms/v1_9_R1/v1_9_R1SlimeNMS.java
+++ b/slimeworldmanager-nms-v1_9_R1/src/main/java/com/grinderwolf/swm/nms/v1_9_R1/v1_9_R1SlimeNMS.java
@@ -66,14 +66,19 @@ public class v1_9_R1SlimeNMS implements SlimeNMS {
     public Object createNMSWorld(SlimeWorld world) {
         CustomDataManager dataManager = new CustomDataManager(world);
         MinecraftServer mcServer = MinecraftServer.getServer();
-
         int dimension = CraftWorld.CUSTOM_DIMENSION_OFFSET + mcServer.worlds.size();
+        boolean used = false;
 
-        for (WorldServer server : mcServer.worlds) {
-            if (server.dimension == dimension) {
-                dimension++;
+        do {
+            for (WorldServer server : mcServer.worlds) {
+                used = server.dimension == dimension;
+
+                if (used) {
+                    dimension++;
+                    break;
+                }
             }
-        }
+        } while (used);
 
         return new CustomWorldServer((CraftSlimeWorld) world, dataManager, dimension);
     }

--- a/slimeworldmanager-nms-v1_9_R2/src/main/java/com/grinderwolf/swm/nms/v1_9_R2/v1_9_R2SlimeNMS.java
+++ b/slimeworldmanager-nms-v1_9_R2/src/main/java/com/grinderwolf/swm/nms/v1_9_R2/v1_9_R2SlimeNMS.java
@@ -68,12 +68,18 @@ public class v1_9_R2SlimeNMS implements SlimeNMS {
         MinecraftServer mcServer = MinecraftServer.getServer();
 
         int dimension = CraftWorld.CUSTOM_DIMENSION_OFFSET + mcServer.worlds.size();
+        boolean used = false;
 
-        for (WorldServer server : mcServer.worlds) {
-            if (server.dimension == dimension) {
-                dimension++;
+        do {
+            for (WorldServer server : mcServer.worlds) {
+                used = server.dimension == dimension;
+
+                if (used) {
+                    dimension++;
+                    break;
+                }
             }
-        }
+        } while (used);
 
         return new CustomWorldServer((CraftSlimeWorld) world, dataManager, dimension);
     }


### PR DESCRIPTION
Dimension IDs are calculated based on the amount of existing worlds at the time of loading. If the server then unloads one of the worlds loaded, it's possible that, when loading another world, it'll pick an already-used dimension id.

Fixes #120.