### PR TITLE
Fix class NotFoundException on Paper-443 (1.8.8)

### DIFF
--- a/slimeworldmanager-classmodifier/pom.xml
+++ b/slimeworldmanager-classmodifier/pom.xml
@@ -9,6 +9,14 @@
 
     <artifactId>slimeworldmanager-classmodifier</artifactId>
 
+    <repositories>
+        <repository>
+            <id>minecraft-libraries</id>
+            <name>Minecraft Libraries</name>
+            <url>https://libraries.minecraft.net</url>
+        </repository>
+    </repositories>
+
     <dependencies>
         <dependency>
             <groupId>org.javassist</groupId>
@@ -16,8 +24,14 @@
             <version>3.25.0-GA</version>
         </dependency>
         <dependency>
+            <groupId>com.mojang</groupId>
+            <artifactId>datafixerupper</artifactId>
+            <version>1.0.20</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>org.spigotmc</groupId>
-            <artifactId>spigot</artifactId>
+            <artifactId>spigot-api</artifactId>
             <version>1.14.4-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>

--- a/slimeworldmanager-classmodifier/src/main/java/com/grinderwolf/swm/clsm/NMSTransformer.java
+++ b/slimeworldmanager-classmodifier/src/main/java/com/grinderwolf/swm/clsm/NMSTransformer.java
@@ -1,6 +1,6 @@
 package com.grinderwolf.swm.clsm;
 
-import javassist.ByteArrayClassPath;
+import javassist.LoaderClassPath;
 import javassist.CannotCompileException;
 import javassist.ClassPool;
 import javassist.CtClass;
@@ -145,7 +145,7 @@ public class NMSTransformer implements ClassFileTransformer {
 
                 try {
                     ClassPool pool = ClassPool.getDefault();
-                    pool.appendClassPath(new ByteArrayClassPath(fixedClassName, bytes));
+                    pool.appendClassPath(new LoaderClassPath(classLoader));
                     CtClass ctClass = pool.get(fixedClassName);
 
                     for (Change change : changes.get(className)) {


### PR DESCRIPTION
Java couldn't find the class WorldType because it wasn't using the
correct classpath. The ByteArrayClassPath will only load the class
we're patching, and not any dependent classes. I'm pretty sure we
don't need both the ByteArrayClassPath and the new LoaderClassPath,
but I only tested with 1.8.8 on Spigot/Paper.

Fixes #158