### PR TITLE
Added 1.16_R3 Support

### DIFF
--- a/.docs/faq.md
+++ b/.docs/faq.md
@@ -3,7 +3,7 @@
 
 * Which Spigot versions is this compatible with?
 
-Currently, SWM can run on any Spigot version from 1.8.8 up to 1.16.2.
+Currently, SWM can run on any Spigot version from 1.8.8 up to 1.16.5.
 
 * Can I override the default world?
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: java
 install:
+  - - wget -O paper-1.16.5.jar papermc.io/api/v1/paper/1.16.5/latest/download && java -Dpaperclip.patchonly=true -jar paper-1.16.5.jar && mvn install:install-file -Dfile=cache/patched_1.16.5.jar -DgroupId=com.destroystokyo.paper -DartifactId=paper -Dversion=1.16.5-R0.1-SNAPSHOT -Dpackaging=jar
     - wget -O paper-1.16.2.jar papermc.io/api/v1/paper/1.16.2/latest/download && java -Dpaperclip.patchonly=true -jar paper-1.16.2.jar && mvn install:install-file -Dfile=cache/patched_1.16.2.jar -DgroupId=com.destroystokyo.paper -DartifactId=paper -Dversion=1.16.2-R0.1-SNAPSHOT -Dpackaging=jar
     - wget https://cdn.getbukkit.org/spigot/spigot-1.15.1.jar && mvn install:install-file -Dfile=spigot-1.15.1.jar -DgroupId=org.spigotmc -DartifactId=spigot -Dversion=1.15.1-R0.1-SNAPSHOT -Dpackaging=jar
     - wget https://cdn.getbukkit.org/spigot/spigot-1.14.4.jar && mvn install:install-file -Dfile=spigot-1.14.4.jar -DgroupId=org.spigotmc -DartifactId=spigot -Dversion=1.14.4-R0.1-SNAPSHOT -Dpackaging=jar

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>com.grinderwolf</groupId>
     <artifactId>slimeworldmanager</artifactId>
     <packaging>pom</packaging>
-    <version>2.3.0-SNAPSHOT</version>
+    <version>2.3.1-SNAPSHOT</version>
     <modules>
         <module>slimeworldmanager-api</module>
         <module>slimeworldmanager-nms-common</module>
@@ -23,6 +23,7 @@
         <module>slimeworldmanager-nms-v1_14_R1</module>
         <module>slimeworldmanager-nms-v1_15_R1</module>
         <module>slimeworldmanager-nms-v1_16_R2</module>
+        <module>slimeworldmanager-nms-v1_16_R3</module>
     </modules>
 
     <repositories>

--- a/slimeworldmanager-api/pom.xml
+++ b/slimeworldmanager-api/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>slimeworldmanager</artifactId>
         <groupId>com.grinderwolf</groupId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/slimeworldmanager-classmodifier/pom.xml
+++ b/slimeworldmanager-classmodifier/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>slimeworldmanager</artifactId>
         <groupId>com.grinderwolf</groupId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/slimeworldmanager-classmodifier/src/main/resources/list.yml
+++ b/slimeworldmanager-classmodifier/src/main/resources/list.yml
@@ -1,3 +1,17 @@
+# 1.16.4/5
+net/minecraft/server/v1_16_R3/PlayerChunkMap:
+  - saveChunk(net.minecraft.server.v1_16_R3.IChunkAccess)@v1_16_R3/PlayerChunkMap_saveChunk.txt
+  - f(net.minecraft.server.v1_16_R3.ChunkCoordIntPair)@v1_16_R3/PlayerChunkMap_loadChunk.txt
+net/minecraft/server/v1_16_R3/MobSpawnerTrader:
+  - a(net.minecraft.server.v1_16_R3.WorldServer,boolean, boolean)@v1_16_R3/MobSpawnerTrader_tickRaids.txt
+net/minecraft/server/v1_16_R3/PersistentBase:
+  - a(java.io.File)@v1_16_R3/PersistentBase_saveData.txt
+net/minecraft/server/v1_16_R3/MinecraftServer:
+  - loadWorld(java.lang.String)@v1_16_R3/MinecraftServer_loadWorlds.txt
+  - getGamemode()@v1_16_R3/MinecraftServer_getGamemode.txt
+org/bukkit/craftbukkit/v1_16_R3/CraftServer:
+  - addWorld(org.bukkit.World)@v1_16_R3/CraftServer_addWorld.txt
+
 # 1.16
 net/minecraft/server/v1_16_R2/PlayerChunkMap:
   - saveChunk(net.minecraft.server.v1_16_R2.IChunkAccess)@v1_16_R2/PlayerChunkMap_saveChunk.txt

--- a/slimeworldmanager-classmodifier/src/main/resources/v1_16_R3/CraftServer_addWorld.txt
+++ b/slimeworldmanager-classmodifier/src/main/resources/v1_16_R3/CraftServer_addWorld.txt
@@ -1,0 +1,5 @@
+{
+    if (com.grinderwolf.swm.clsm.ClassModifier.skipWorldAdd(((org.bukkit.craftbukkit.v1_16_R3.CraftWorld) $1).getHandle())) {
+        return;
+    }
+}

--- a/slimeworldmanager-classmodifier/src/main/resources/v1_16_R3/MinecraftServer_getGamemode.txt
+++ b/slimeworldmanager-classmodifier/src/main/resources/v1_16_R3/MinecraftServer_getGamemode.txt
@@ -1,0 +1,7 @@
+{
+    net.minecraft.server.v1_16_R3.EnumGamemode gamemode = (net.minecraft.server.v1_16_R3.EnumGamemode) com.grinderwolf.swm.clsm.ClassModifier.getDefaultGamemode();
+
+    if (gamemode != null) {
+        return gamemode;
+    }
+}

--- a/slimeworldmanager-classmodifier/src/main/resources/v1_16_R3/MinecraftServer_loadWorlds.txt
+++ b/slimeworldmanager-classmodifier/src/main/resources/v1_16_R3/MinecraftServer_loadWorlds.txt
@@ -1,0 +1,208 @@
+{
+    net.minecraft.server.v1_16_R3.WorldServer[] defaultWorlds = (net.minecraft.server.v1_16_R3.WorldServer[]) com.grinderwolf.swm.clsm.ClassModifier.getDefaultWorlds();
+
+    if (defaultWorlds != null) {
+        System.out.println("Overriding default worlds");
+        int worldCount = 3;
+
+        for (int worldId = 0; worldId < worldCount; ++worldId) {
+            byte dimension = 0;
+            net.minecraft.server.v1_16_R3.ResourceKey dimensionKey = net.minecraft.server.v1_16_R3.WorldDimension.OVERWORLD;
+
+            if (worldId == 1) {
+                if ($0.getAllowNether()) {
+                    dimension = -1;
+                    dimensionKey = net.minecraft.server.v1_16_R3.WorldDimension.THE_NETHER;
+                } else {
+                    continue;
+                }
+            }
+
+            if (worldId == 2) {
+                if ($0.server.getAllowEnd()) {
+                    dimension = 1;
+                    dimensionKey = net.minecraft.server.v1_16_R3.WorldDimension.THE_END;
+                } else {
+                    continue;
+                }
+            }
+
+            net.minecraft.server.v1_16_R3.WorldServer world = defaultWorlds[worldId];
+            net.minecraft.server.v1_16_R3.WorldDataServer worlddata;
+
+            if (world == null) {
+                java.lang.String worldType = org.bukkit.World.Environment.getEnvironment(dimension).toString().toLowerCase();
+                java.lang.String name = dimension == 0 ? $1 : $1 + "_" + worldType;
+                net.minecraft.server.v1_16_R3.Convertable.ConversionSession worldSession;
+
+                if (worldId == 0) {
+                    worldSession = $0.convertable;
+                } else {
+                    java.lang.String dim = "DIM" + dimension;
+                    java.io.File newWorld = new java.io.File(new java.io.File(name), dim);
+                    java.io.File oldWorld = new java.io.File(new java.io.File(s), dim);
+                    java.io.File oldLevelDat = new java.io.File(new java.io.File(s), "level.dat");
+                    if (!newWorld.isDirectory() && oldWorld.isDirectory() && oldLevelDat.isFile()) {
+                        LOGGER.info("---- Migration of old " + worldType + " folder required ----");
+                        LOGGER.info("Unfortunately due to the way that Minecraft implemented multiworld support in 1.6, Bukkit requires that you move your " + worldType + " folder to a new location in order to operate correctly.");
+                        LOGGER.info("We will move this folder for you, but it will mean that you need to move it back should you wish to stop using Bukkit in the future.");
+                        LOGGER.info("Attempting to move " + oldWorld + " to " + newWorld + "...");
+                        if (newWorld.exists()) {
+                            LOGGER.warn("A file or folder already exists at " + newWorld + "!");
+                            LOGGER.info("---- Migration of old " + worldType + " folder failed ----");
+                        } else if (newWorld.getParentFile().mkdirs()) {
+                            if (oldWorld.renameTo(newWorld)) {
+                                LOGGER.info("Success! To restore " + worldType + " in the future, simply move " + newWorld + " to " + oldWorld);
+
+                                try {
+                                    com.google.common.io.Files.copy(oldLevelDat, new java.io.File(new java.io.File(name), "level.dat"));
+                                    org.bukkit.craftbukkit.libs.org.apache.commons.io.FileUtils.copyDirectory(new java.io.File(new java.io.File(s), "data"), new java.io.File(new java.io.File(name), "data"));
+                                } catch (java.io.IOException ex) {
+                                    LOGGER.warn("Unable to migrate world data.");
+                                }
+
+                                LOGGER.info("---- Migration of old " + worldType + " folder complete ----");
+                            } else {
+                                LOGGER.warn("Could not move folder " + oldWorld + " to " + newWorld + "!");
+                                LOGGER.info("---- Migration of old " + worldType + " folder failed ----");
+                            }
+                        } else {
+                            LOGGER.warn("Could not create path for " + newWorld + "!");
+                            LOGGER.info("---- Migration of old " + worldType + " folder failed ----");
+                        }
+                    }
+
+                    try {
+                        worldSession = net.minecraft.server.v1_16_R3.Convertable.a($0.server.getWorldContainer().toPath()).c(name, dimensionKey);
+                    } catch (java.io.IOException ex) {
+                        throw new java.lang.RuntimeException(ex);
+                    }
+
+                    convertWorld(worldSession);
+                }
+
+                org.bukkit.generator.ChunkGenerator gen = $0.server.getGenerator(name);
+                net.minecraft.server.v1_16_R3.IRegistryCustom.Dimension iregistrycustom_dimension = $0.customRegistry;
+                net.minecraft.server.v1_16_R3.RegistryReadOps registryreadops = net.minecraft.server.v1_16_R3.RegistryReadOps.a(net.minecraft.server.v1_16_R3.DynamicOpsNBT.a, $0.dataPackResources.h(), iregistrycustom_dimension);
+                worlddata = (net.minecraft.server.v1_16_R3.WorldDataServer) worldSession.a(registryreadops, $0.datapackconfiguration);
+                net.minecraft.server.v1_16_R3.GeneratorSettings generatorsettings;
+
+                if (worlddata == null) {
+                    net.minecraft.server.v1_16_R3.WorldSettings worldsettings;
+
+                    if ($0.isDemoMode()) {
+                        worldsettings = c;
+                        generatorsettings = net.minecraft.server.v1_16_R3.GeneratorSettings.a(iregistrycustom_dimension);
+                    } else {
+                        net.minecraft.server.v1_16_R3.DedicatedServerProperties dedicatedserverproperties = ((net.minecraft.server.v1_16_R3.DedicatedServer)this).getDedicatedServerProperties();
+                        worldsettings = new net.minecraft.server.v1_16_R3.WorldSettings(dedicatedserverproperties.levelName, dedicatedserverproperties.gamemode, dedicatedserverproperties.hardcore, dedicatedserverproperties.difficulty, false, new net.minecraft.server.v1_16_R3.GameRules(), $0.datapackconfiguration);
+                        generatorsettings = $0.options.has("bonusChest") ? dedicatedserverproperties.generatorSettings.j() : dedicatedserverproperties.generatorSettings;
+                    }
+
+                    worlddata = new net.minecraft.server.v1_16_R3.WorldDataServer(worldsettings, generatorsettings, com.mojang.serialization.Lifecycle.stable());
+                }
+
+                worlddata.checkName(name);
+
+                if ($0.options.has("forceUpgrade")) {
+                    java.util.Set entrySet = worlddata.getGeneratorSettings().d();
+                    java.util.Set resourceKeySet = new java.util.HashSet(entrySet.size());
+                    java.util.Iterator entryIt = entrySet.iterator();
+
+                    while (entryIt.hasNext()) {
+                        java.util.Map.Entry entry = (java.util.Map.Entry) entryIt.next();
+
+                        resourceKeySet.add(net.minecraft.server.v1_16_R3.ResourceKey.a(net.minecraft.server.v1_16_R3.IRegistry.K, ((net.minecraft.server.v1_16_R3.ResourceKey) entry.getKey()).a()));
+                    }
+
+                    net.minecraft.server.v1_16_R3.Main.convertWorld(worldSession, net.minecraft.server.v1_16_R3.DataConverterRegistry.a(), $0.options.has("eraseCache"), com.grinderwolf.swm.clsm.ClassModifier.BOOLEAN_SUPPLIER, com.google.common.collect.ImmutableSet.of(resourceKeySet));
+                }
+
+                generatorsettings = worlddata.getGeneratorSettings();
+                boolean flag = generatorsettings.isDebugWorld();
+                long i = generatorsettings.getSeed();
+                long j = net.minecraft.server.v1_16_R3.BiomeManager.a(i);
+                java.util.List list = com.google.common.collect.ImmutableList.of(new net.minecraft.server.v1_16_R3.MobSpawnerPhantom(), new net.minecraft.server.v1_16_R3.MobSpawnerPatrol(), new net.minecraft.server.v1_16_R3.MobSpawnerCat(), new net.minecraft.server.v1_16_R3.VillageSiege(), new net.minecraft.server.v1_16_R3.MobSpawnerTrader(worlddata));
+                net.minecraft.server.v1_16_R3.RegistryMaterials registrymaterials = generatorsettings.d();
+                net.minecraft.server.v1_16_R3.WorldDimension worlddimension = (net.minecraft.server.v1_16_R3.WorldDimension)registrymaterials.a(dimensionKey);
+                net.minecraft.server.v1_16_R3.DimensionManager dimensionmanager;
+                java.lang.Object chunkgenerator;
+                if (worlddimension == null) {
+                    dimensionmanager = (net.minecraft.server.v1_16_R3.DimensionManager)$0.customRegistry.a().d(net.minecraft.server.v1_16_R3.DimensionManager.OVERWORLD);
+                    chunkgenerator = net.minecraft.server.v1_16_R3.GeneratorSettings.a($0.customRegistry.b(net.minecraft.server.v1_16_R3.IRegistry.ay), $0.customRegistry.b(net.minecraft.server.v1_16_R3.IRegistry.ar), (new java.util.Random()).nextLong());
+                } else {
+                    dimensionmanager = worlddimension.b();
+                    chunkgenerator = worlddimension.c();
+                }
+
+                net.minecraft.server.v1_16_R3.ResourceKey worldKey = net.minecraft.server.v1_16_R3.ResourceKey.a(net.minecraft.server.v1_16_R3.IRegistry.L, dimensionKey.a());
+                net.minecraft.server.v1_16_R3.WorldLoadListener worldloadlistener = $0.worldLoadListenerFactory.create(11);
+
+                if (worldId == 0) {
+                    world = new net.minecraft.server.v1_16_R3.WorldServer($0, $0.executorService, worldSession, worlddata, worldKey, dimensionmanager, worldloadlistener, (net.minecraft.server.v1_16_R3.ChunkGenerator)chunkgenerator, flag, j, list, true, org.bukkit.World.Environment.getEnvironment(dimension), gen);
+                } else {
+                    world = new net.minecraft.server.v1_16_R3.WorldServer($0, $0.executorService, worldSession, worlddata, worldKey, dimensionmanager, worldloadlistener, (net.minecraft.server.v1_16_R3.ChunkGenerator)chunkgenerator, flag, j, com.google.common.collect.ImmutableList.of(), true, org.bukkit.World.Environment.getEnvironment(dimension), gen);
+                }
+            } else {
+                worlddata = world.worldDataServer;
+            }
+
+            if (worldId == 0) {
+                $0.saveData = worlddata;
+                $0.saveData.setGameType(((net.minecraft.server.v1_16_R3.DedicatedServer) $0).getDedicatedServerProperties().gamemode);
+
+                net.minecraft.server.v1_16_R3.WorldPersistentData worldpersistentdata = world.getWorldPersistentData();
+                $0.initializeScoreboards(worldpersistentdata);
+                $0.server.scoreboardManager = new org.bukkit.craftbukkit.v1_16_R3.scoreboard.CraftScoreboardManager($0, world.getScoreboard());
+                $0.persistentCommandStorage = new net.minecraft.server.v1_16_R3.PersistentCommandStorage(worldpersistentdata);
+            }
+
+            worlddata.a($0.getServerModName(), $0.getModded().isPresent());
+            $0.initWorld(world, worlddata, saveData, worlddata.getGeneratorSettings());
+            $0.server.getPluginManager().callEvent(new org.bukkit.event.world.WorldInitEvent(world.getWorld()));
+
+            $0.worldServer.put(world.getDimensionKey(), world);
+            $0.getPlayerList().setPlayerFileData(world);
+
+            if (worlddata.getCustomBossEvents() != null) {
+                $0.getBossBattleCustomData().load(worlddata.getCustomBossEvents());
+            }
+        }
+        $0.updateWorldSettings();
+
+        java.util.Iterator worldList = $0.getWorlds().iterator();
+
+        while (worldList.hasNext()) {
+            net.minecraft.server.v1_16_R3.WorldServer worldserver = (net.minecraft.server.v1_16_R3.WorldServer) worldList.next();
+            $0.loadSpawn(worldserver.getChunkProvider().playerChunkMap.worldLoadListener, worldserver);
+            $0.server.getPluginManager().callEvent(new org.bukkit.event.world.WorldLoadEvent(worldserver.getWorld()));
+        }
+
+        net.minecraft.server.v1_16_R3.Scoreboard scoreboard = $0.getScoreboard();
+        java.util.List teams = new java.util.ArrayList(scoreboard.getTeams());
+        java.util.Iterator teamsIt = teams.iterator();
+
+        while (teamsIt.hasNext()) {
+            net.minecraft.server.v1_16_R3.ScoreboardTeam team = (net.minecraft.server.v1_16_R3.ScoreboardTeam) teamsIt.next();
+
+            if (team.getName().startsWith("collideRule_")) {
+                scoreboard.removeTeam(team);
+            }
+        }
+
+        try {
+            if (!com.destroystokyo.paper.PaperConfig.enablePlayerCollisions) {
+                $0.getPlayerList().collideRuleTeamName = org.bukkit.craftbukkit.libs.org.apache.commons.lang3.StringUtils.left("collideRule_" + java.util.concurrent.ThreadLocalRandom.current().nextInt(), 16);
+                net.minecraft.server.v1_16_R3.ScoreboardTeam collideTeam = scoreboard.createTeam($0.getPlayerList().collideRuleTeamName);
+                collideTeam.setCanSeeFriendlyInvisibles(false);
+            }
+        } catch (ClassNotFoundException ex) {
+
+        }
+
+        $0.server.enablePlugins(org.bukkit.plugin.PluginLoadOrder.POSTWORLD);
+        $0.server.getPluginManager().callEvent(new org.bukkit.event.server.ServerLoadEvent(org.bukkit.event.server.ServerLoadEvent.LoadType.STARTUP));
+        $0.serverConnection.acceptConnections();
+        return;
+    }
+}

--- a/slimeworldmanager-classmodifier/src/main/resources/v1_16_R3/MobSpawnerTrader_tickRaids.txt
+++ b/slimeworldmanager-classmodifier/src/main/resources/v1_16_R3/MobSpawnerTrader_tickRaids.txt
@@ -1,0 +1,5 @@
+{
+    if (com.grinderwolf.swm.clsm.ClassModifier.isCustomWorld($0.b)) {
+        return 0;
+    }
+}

--- a/slimeworldmanager-classmodifier/src/main/resources/v1_16_R3/PersistentBase_saveData.txt
+++ b/slimeworldmanager-classmodifier/src/main/resources/v1_16_R3/PersistentBase_saveData.txt
@@ -1,0 +1,6 @@
+{
+    if (!$1.getParentFile().exists()) {
+        $0.a(false);
+        return;
+    }
+}

--- a/slimeworldmanager-classmodifier/src/main/resources/v1_16_R3/PlayerChunkMap_loadChunk.txt
+++ b/slimeworldmanager-classmodifier/src/main/resources/v1_16_R3/PlayerChunkMap_loadChunk.txt
@@ -1,0 +1,7 @@
+{ 
+    java.util.concurrent.CompletableFuture chunk = com.grinderwolf.swm.clsm.ClassModifier.getFutureChunk($0.world, $1.x, $1.z);
+    
+    if (chunk != null) { 
+        return chunk;
+    }
+}

--- a/slimeworldmanager-classmodifier/src/main/resources/v1_16_R3/PlayerChunkMap_saveChunk.txt
+++ b/slimeworldmanager-classmodifier/src/main/resources/v1_16_R3/PlayerChunkMap_saveChunk.txt
@@ -1,0 +1,5 @@
+{
+    if (com.grinderwolf.swm.clsm.ClassModifier.saveChunk($0.world, $1)) {
+        return false;
+    }
+}

--- a/slimeworldmanager-importer/pom.xml
+++ b/slimeworldmanager-importer/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>slimeworldmanager</artifactId>
         <groupId>com.grinderwolf</groupId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>slimeworldmanager-importer</artifactId>

--- a/slimeworldmanager-nms-common/pom.xml
+++ b/slimeworldmanager-nms-common/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>slimeworldmanager</artifactId>
         <groupId>com.grinderwolf</groupId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <properties>

--- a/slimeworldmanager-nms-v1_10_R1/pom.xml
+++ b/slimeworldmanager-nms-v1_10_R1/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>slimeworldmanager</artifactId>
         <groupId>com.grinderwolf</groupId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <properties>

--- a/slimeworldmanager-nms-v1_11_R1/pom.xml
+++ b/slimeworldmanager-nms-v1_11_R1/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>slimeworldmanager</artifactId>
         <groupId>com.grinderwolf</groupId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <properties>

--- a/slimeworldmanager-nms-v1_12_R1/pom.xml
+++ b/slimeworldmanager-nms-v1_12_R1/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>slimeworldmanager</artifactId>
         <groupId>com.grinderwolf</groupId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <properties>

--- a/slimeworldmanager-nms-v1_13_R1/pom.xml
+++ b/slimeworldmanager-nms-v1_13_R1/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>slimeworldmanager</artifactId>
         <groupId>com.grinderwolf</groupId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <properties>

--- a/slimeworldmanager-nms-v1_13_R2/pom.xml
+++ b/slimeworldmanager-nms-v1_13_R2/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>slimeworldmanager</artifactId>
         <groupId>com.grinderwolf</groupId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <properties>

--- a/slimeworldmanager-nms-v1_14_R1/pom.xml
+++ b/slimeworldmanager-nms-v1_14_R1/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>slimeworldmanager</artifactId>
         <groupId>com.grinderwolf</groupId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <properties>

--- a/slimeworldmanager-nms-v1_16_R2/pom.xml
+++ b/slimeworldmanager-nms-v1_16_R2/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>slimeworldmanager</artifactId>
         <groupId>com.grinderwolf</groupId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <properties>

--- a/slimeworldmanager-nms-v1_16_R3/pom.xml
+++ b/slimeworldmanager-nms-v1_16_R3/pom.xml
@@ -10,7 +10,7 @@
         <maven.deploy.skip>true</maven.deploy.skip>
     </properties>
 
-    <artifactId>slimeworldmanager-nms-v1_15_R1</artifactId>
+    <artifactId>slimeworldmanager-nms-v1_16_R3</artifactId>
 
     <dependencies>
         <dependency>
@@ -26,9 +26,9 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.spigotmc</groupId>
-            <artifactId>spigot</artifactId>
-            <version>1.15.1-R0.1-SNAPSHOT</version>
+            <groupId>com.destroystokyo.paper</groupId>
+            <artifactId>paper</artifactId>
+            <version>1.16.5-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/slimeworldmanager-nms-v1_16_R3/src/main/java/com/grinderwolf/swm/v1_16_R3/Converter.java
+++ b/slimeworldmanager-nms-v1_16_R3/src/main/java/com/grinderwolf/swm/v1_16_R3/Converter.java
@@ -1,0 +1,119 @@
+package com.grinderwolf.swm.v1_16_R3;
+
+import com.flowpowered.nbt.*;
+import com.flowpowered.nbt.Tag;
+import com.grinderwolf.swm.api.utils.NibbleArray;
+import net.minecraft.server.v1_16_R3.*;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class Converter {
+
+    private static final Logger LOGGER = LogManager.getLogger("SWM Converter");
+
+    static net.minecraft.server.v1_16_R3.NibbleArray convertArray(NibbleArray array) {
+        return new net.minecraft.server.v1_16_R3.NibbleArray(array.getBacking());
+    }
+
+    static NibbleArray convertArray(net.minecraft.server.v1_16_R3.NibbleArray array) {
+        if (array == null) {
+            return null;
+        }
+
+        return new NibbleArray(array.asBytes());
+    }
+
+    static NBTBase convertTag(Tag tag) {
+        try {
+            switch (tag.getType()) {
+                case TAG_BYTE:
+                    return NBTTagByte.a(((ByteTag) tag).getValue());
+                case TAG_SHORT:
+                    return NBTTagShort.a(((ShortTag) tag).getValue());
+                case TAG_INT:
+                    return NBTTagInt.a(((IntTag) tag).getValue());
+                case TAG_LONG:
+                    return NBTTagLong.a(((LongTag) tag).getValue());
+                case TAG_FLOAT:
+                    return NBTTagFloat.a(((FloatTag) tag).getValue());
+                case TAG_DOUBLE:
+                    return NBTTagDouble.a(((DoubleTag) tag).getValue());
+                case TAG_BYTE_ARRAY:
+                    return new NBTTagByteArray(((ByteArrayTag) tag).getValue());
+                case TAG_STRING:
+                    return NBTTagString.a(((StringTag) tag).getValue());
+                case TAG_LIST:
+                    NBTTagList list = new NBTTagList();
+                    ((ListTag<?>) tag).getValue().stream().map(Converter::convertTag).forEach(list::add);
+
+                    return list;
+                case TAG_COMPOUND:
+                    NBTTagCompound compound = new NBTTagCompound();
+
+                    ((CompoundTag) tag).getValue().forEach((key, value) -> compound.set(key, convertTag(value)));
+
+                    return compound;
+                case TAG_INT_ARRAY:
+                    return new NBTTagIntArray(((IntArrayTag) tag).getValue());
+                case TAG_LONG_ARRAY:
+                    return new NBTTagLongArray(((LongArrayTag) tag).getValue());
+                default:
+                    throw new IllegalArgumentException("Invalid tag type " + tag.getType().name());
+            }
+        } catch (Exception ex) {
+            LOGGER.error("Failed to convert NBT object:");
+            LOGGER.error(tag.toString());
+
+            throw ex;
+        }
+    }
+
+    static Tag convertTag(String name, NBTBase base) {
+        switch (base.getTypeId()) {
+            case 1:
+                return new ByteTag(name, ((NBTTagByte) base).asByte());
+            case 2:
+                return new ShortTag(name, ((NBTTagShort) base).asShort());
+            case 3:
+                return new IntTag(name, ((NBTTagInt) base).asInt());
+            case 4:
+                return new LongTag(name, ((NBTTagLong) base).asLong());
+            case 5:
+                return new FloatTag(name, ((NBTTagFloat) base).asFloat());
+            case 6:
+                return new DoubleTag(name, ((NBTTagDouble) base).asDouble());
+            case 7:
+                return new ByteArrayTag(name, ((NBTTagByteArray) base).getBytes());
+            case 8:
+                return new StringTag(name, ((NBTTagString) base).asString());
+            case 9:
+                List<Tag> list = new ArrayList<>();
+                NBTTagList originalList = ((NBTTagList) base);
+
+                for (NBTBase entry : originalList) {
+                    list.add(convertTag("", entry));
+                }
+
+                return new ListTag<>(name, TagType.getById(originalList.d_()), list);
+            case 10:
+                NBTTagCompound originalCompound = ((NBTTagCompound) base);
+                CompoundTag compound = new CompoundTag(name, new CompoundMap());
+
+                for (String key : originalCompound.getKeys()) {
+                    compound.getValue().put(key, convertTag(key, originalCompound.get(key)));
+                }
+
+                return compound;
+            case 11:
+                return new IntArrayTag("", ((NBTTagIntArray) base).getInts());
+            case 12:
+                return new LongArrayTag("", ((NBTTagLongArray) base).getLongs());
+            default:
+                throw new IllegalArgumentException("Invalid tag type " + base.getTypeId());
+        }
+    }
+
+}

--- a/slimeworldmanager-nms-v1_16_R3/src/main/java/com/grinderwolf/swm/v1_16_R3/CraftCLSMBridge.java
+++ b/slimeworldmanager-nms-v1_16_R3/src/main/java/com/grinderwolf/swm/v1_16_R3/CraftCLSMBridge.java
@@ -1,0 +1,95 @@
+package com.grinderwolf.swm.v1_16_R3;
+
+import com.grinderwolf.swm.clsm.CLSMBridge;
+import com.grinderwolf.swm.clsm.ClassModifier;
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+import net.minecraft.server.v1_16_R3.*;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public class CraftCLSMBridge implements CLSMBridge {
+
+    private static final Logger LOGGER = LogManager.getLogger("SWM Chunk Loader");
+
+    private final v1_16_R3SlimeNMS nmsInstance;
+
+    @Override
+    public Object getChunk(Object worldObject, int x, int z) {
+        if (!(worldObject instanceof CustomWorldServer)) {
+            return null; // Returning null will just run the original getChunk method
+        }
+
+        CustomWorldServer world = (CustomWorldServer) worldObject;
+        return world.getChunk(x, z);
+    }
+
+    @Override
+    public boolean saveChunk(Object world, Object chunkAccess) {
+        if (!(world instanceof CustomWorldServer)) {
+            return false; // Returning false will just run the original saveChunk method
+        }
+
+        if (!(chunkAccess instanceof ProtoChunkExtension || chunkAccess instanceof Chunk) || !((IChunkAccess) chunkAccess).isNeedsSaving()) {
+            // We're only storing fully-loaded chunks that need to be saved
+            return true;
+        }
+
+        Chunk chunk;
+
+        if (chunkAccess instanceof ProtoChunkExtension) {
+            chunk = ((ProtoChunkExtension) chunkAccess).u();
+        } else {
+            chunk = (Chunk) chunkAccess;
+        }
+
+        ((CustomWorldServer) world).saveChunk(chunk);
+        chunk.setNeedsSaving(false);
+
+        return true;
+    }
+
+    @Override
+    public Object[] getDefaultWorlds() {
+        WorldServer defaultWorld = nmsInstance.getDefaultWorld();
+        WorldServer netherWorld = nmsInstance.getDefaultNetherWorld();
+        WorldServer endWorld = nmsInstance.getDefaultEndWorld();
+
+        if (defaultWorld != null || netherWorld != null || endWorld != null) {
+            return new WorldServer[] { defaultWorld, netherWorld, endWorld };
+        }
+
+        // Returning null will just run the original load world method
+        return null;
+    }
+
+    @Override
+    public boolean isCustomWorld(Object world) {
+        return world instanceof CustomWorldServer;
+    }
+
+    @Override
+    public boolean skipWorldAdd(Object world) {
+        if (!isCustomWorld(world) || nmsInstance.isLoadingDefaultWorlds()) {
+            return false;
+        }
+
+        CustomWorldServer worldServer = (CustomWorldServer) world;
+        return !worldServer.isReady();
+    }
+
+    @Override
+    public Object getDefaultGamemode() {
+        if (nmsInstance.isLoadingDefaultWorlds()) {
+            return ((DedicatedServer) MinecraftServer.getServer()).getDedicatedServerProperties().gamemode;
+        }
+
+        return null;
+    }
+
+    static void initialize(v1_16_R3SlimeNMS instance) {
+        ClassModifier.setLoader(new CraftCLSMBridge(instance));
+    }
+
+}

--- a/slimeworldmanager-nms-v1_16_R3/src/main/java/com/grinderwolf/swm/v1_16_R3/CustomWorldServer.java
+++ b/slimeworldmanager-nms-v1_16_R3/src/main/java/com/grinderwolf/swm/v1_16_R3/CustomWorldServer.java
@@ -1,0 +1,303 @@
+package com.grinderwolf.swm.v1_16_R3;
+
+import com.flowpowered.nbt.CompoundMap;
+import com.flowpowered.nbt.CompoundTag;
+import com.flowpowered.nbt.LongArrayTag;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import com.grinderwolf.swm.api.exceptions.UnknownWorldException;
+import com.grinderwolf.swm.api.world.SlimeChunk;
+import com.grinderwolf.swm.api.world.SlimeChunkSection;
+import com.grinderwolf.swm.api.world.properties.SlimeProperties;
+import com.grinderwolf.swm.api.world.properties.SlimePropertyMap;
+import com.grinderwolf.swm.nms.CraftSlimeChunk;
+import com.grinderwolf.swm.nms.CraftSlimeWorld;
+import lombok.Getter;
+import lombok.Setter;
+import net.minecraft.server.v1_16_R3.*;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.bukkit.Bukkit;
+import org.bukkit.event.world.WorldSaveEvent;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.function.Consumer;
+
+public class CustomWorldServer extends WorldServer {
+
+    private static final Logger LOGGER = LogManager.getLogger("SWM World");
+    private static final ExecutorService WORLD_SAVER_SERVICE = Executors.newFixedThreadPool(4, new ThreadFactoryBuilder()
+            .setNameFormat("SWM Pool Thread #%1$d").build());
+    private static final TicketType<Unit> SWM_TICKET = TicketType.a("swm-chunk", (a, b) -> 0);
+
+    @Getter
+    private final CraftSlimeWorld slimeWorld;
+    private final Object saveLock = new Object();
+
+    @Getter
+    @Setter
+    private boolean ready = false;
+
+    public CustomWorldServer(CraftSlimeWorld world, IWorldDataServer worldData,
+                             ResourceKey<World> worldKey, ResourceKey<WorldDimension> dimensionKey,
+                             DimensionManager dimensionManager, ChunkGenerator chunkGenerator,
+                             org.bukkit.World.Environment environment) throws IOException {
+        super(MinecraftServer.getServer(), MinecraftServer.getServer().executorService,
+                v1_16_R3SlimeNMS.CONVERTABLE.c(world.getName(), dimensionKey),
+                worldData, worldKey, dimensionManager, MinecraftServer.getServer().worldLoadListenerFactory.create(11),
+                chunkGenerator, false, 0, new ArrayList<>(), true, environment, null);
+
+        this.slimeWorld = world;
+
+        SlimePropertyMap propertyMap = world.getPropertyMap();
+
+        worldDataServer.setDifficulty(EnumDifficulty.valueOf(propertyMap.getString(SlimeProperties.DIFFICULTY).toUpperCase()));
+        worldDataServer.setSpawn(new BlockPosition(propertyMap.getInt(SlimeProperties.SPAWN_X), propertyMap.getInt(SlimeProperties.SPAWN_Y), propertyMap.getInt(SlimeProperties.SPAWN_Z)), 0);
+        super.setSpawnFlags(propertyMap.getBoolean(SlimeProperties.ALLOW_MONSTERS), propertyMap.getBoolean(SlimeProperties.ALLOW_ANIMALS));
+
+        this.pvpMode = propertyMap.getBoolean(SlimeProperties.PVP);
+    }
+
+    @Override
+    public void save(IProgressUpdate progressUpdate, boolean forceSave, boolean flag1) {
+        if (!slimeWorld.isReadOnly() && !flag1) {
+            if (forceSave) { // TODO Is this really 'forceSave'? Doesn't look like it tbh
+                Bukkit.getPluginManager().callEvent(new WorldSaveEvent(getWorld()));
+            }
+
+            this.timings.worldSaveChunks.startTiming();
+            this.getChunkProvider().save(forceSave);
+            this.timings.worldSaveChunks.stopTiming();
+            this.worldDataServer.a(this.getWorldBorder().t());
+            this.worldDataServer.setCustomBossEvents(MinecraftServer.getServer().getBossBattleCustomData().save());
+
+            // Update level data
+            NBTTagCompound compound = new NBTTagCompound();
+            worldDataServer.a(MinecraftServer.getServer().customRegistry, compound);
+            slimeWorld.getExtraData().getValue().put(Converter.convertTag("LevelData", compound));
+
+            if (MinecraftServer.getServer().isStopped()) { // Make sure the world gets saved before stopping the server by running it from the main thread
+                save();
+
+                // Have to manually unlock the world as well
+                try {
+                    slimeWorld.getLoader().unlockWorld(slimeWorld.getName());
+                } catch (IOException ex) {
+                    LOGGER.error("Failed to unlock the world " + slimeWorld.getName() + ". Please unlock it manually by using the command /swm manualunlock. Stack trace:");
+
+                    ex.printStackTrace();
+                } catch (UnknownWorldException ignored) {
+
+                }
+            } else {
+                WORLD_SAVER_SERVICE.execute(this::save);
+            }
+        }
+    }
+
+    private void save() {
+        synchronized (saveLock) { // Don't want to save the SlimeWorld from multiple threads simultaneously
+            try {
+                LOGGER.info("Saving world " + slimeWorld.getName() + "...");
+                long start = System.currentTimeMillis();
+                byte[] serializedWorld = slimeWorld.serialize();
+                slimeWorld.getLoader().saveWorld(slimeWorld.getName(), serializedWorld, false);
+                LOGGER.info("World " + slimeWorld.getName() + " saved in " + (System.currentTimeMillis() - start) + "ms.");
+            } catch (IOException ex) {
+                ex.printStackTrace();
+            }
+        }
+    }
+
+    ProtoChunkExtension getChunk(int x, int z) {
+        SlimeChunk slimeChunk = slimeWorld.getChunk(x, z);
+        Chunk chunk;
+
+        if (slimeChunk instanceof NMSSlimeChunk) {
+            chunk = ((NMSSlimeChunk) slimeChunk).getChunk();
+        } else {
+            if (slimeChunk == null) {
+                ChunkCoordIntPair pos = new ChunkCoordIntPair(x, z);
+
+                ChunkGenerator chunkGenerator = getChunkProvider().getChunkGenerator();
+                WorldChunkManager chunkManager = chunkGenerator.getWorldChunkManager();
+
+                // Biomes
+                BiomeStorage biomeStorage = new BiomeStorage(r().b(IRegistry.ay), pos, chunkManager, new int[BiomeStorage.a]);
+
+                // Tick lists
+                ProtoChunkTickList<Block> blockTickList = new ProtoChunkTickList<>((block) ->
+                        block == null || block.getBlockData().isAir(), pos);
+                ProtoChunkTickList<FluidType> fluidTickList = new ProtoChunkTickList<>((type) ->
+                        type == null || type == FluidTypes.EMPTY, pos);
+
+                chunk = new Chunk(this, pos, biomeStorage, ChunkConverter.a, blockTickList, fluidTickList,
+                        0L, null, null);
+
+                // Height Maps
+                HeightMap.a(chunk, ChunkStatus.FULL.h());
+            } else {
+                chunk = createChunk(slimeChunk);
+            }
+
+            slimeWorld.updateChunk(new NMSSlimeChunk(chunk));
+        }
+
+        return new ProtoChunkExtension(chunk);
+    }
+
+    private Chunk createChunk(SlimeChunk chunk) {
+        int x = chunk.getX();
+        int z = chunk.getZ();
+
+        LOGGER.debug("Loading chunk (" + x + ", " + z + ") on world " + slimeWorld.getName());
+
+        ChunkCoordIntPair pos = new ChunkCoordIntPair(x, z);
+
+        // Biomes
+        int[] biomeIntArray = chunk.getBiomes();
+
+        BiomeStorage biomeStorage = new BiomeStorage(MinecraftServer.getServer().getCustomRegistry().b(IRegistry.ay), pos,
+                getChunkProvider().getChunkGenerator().getWorldChunkManager(), biomeIntArray);
+
+        // Tick lists
+        ProtoChunkTickList<Block> blockTickList = new ProtoChunkTickList<>(
+                (block) -> block == null || block.getBlockData().isAir(), pos);
+        ProtoChunkTickList<FluidType> fluidTickList = new ProtoChunkTickList<>(
+                (type) -> type == null || type == FluidTypes.EMPTY, pos);
+
+        // Chunk sections
+        LOGGER.debug("Loading chunk sections for chunk (" + pos.x + ", " + pos.z + ") on world " + slimeWorld.getName());
+        ChunkSection[] sections = new ChunkSection[16];
+        LightEngine lightEngine = getChunkProvider().getLightEngine();
+
+        lightEngine.b(pos, true);
+
+        for (int sectionId = 0; sectionId < chunk.getSections().length; sectionId++) {
+            SlimeChunkSection slimeSection = chunk.getSections()[sectionId];
+
+            if (slimeSection != null) {
+                ChunkSection section = new ChunkSection(sectionId << 4);
+
+                LOGGER.debug("ChunkSection #" + sectionId + " - Chunk (" + pos.x + ", " + pos.z + ") - World " + slimeWorld.getName() + ":");
+                LOGGER.debug("Block palette:");
+                LOGGER.debug(slimeSection.getPalette().toString());
+                LOGGER.debug("Block states array:");
+                LOGGER.debug(slimeSection.getBlockStates());
+                LOGGER.debug("Block light array:");
+                LOGGER.debug(slimeSection.getBlockLight() != null ? slimeSection.getBlockLight().getBacking() : "Not present");
+                LOGGER.debug("Sky light array:");
+                LOGGER.debug(slimeSection.getSkyLight() != null ? slimeSection.getSkyLight().getBacking() : "Not present");
+
+                section.getBlocks().a((NBTTagList) Converter.convertTag(slimeSection.getPalette()), slimeSection.getBlockStates());
+
+                if (slimeSection.getBlockLight() != null) {
+                    lightEngine.a(EnumSkyBlock.BLOCK, SectionPosition.a(pos, sectionId), Converter.convertArray(slimeSection.getBlockLight()), true);
+                }
+
+                if (slimeSection.getSkyLight() != null) {
+                    lightEngine.a(EnumSkyBlock.SKY, SectionPosition.a(pos, sectionId), Converter.convertArray(slimeSection.getSkyLight()), true);
+                }
+
+                section.recalcBlockCounts();
+                sections[sectionId] = section;
+            }
+        }
+
+        // Keep the chunk loaded at level 33 to avoid light glitches
+        // Such a high level will let the server not tick the chunk,
+        // but at the same time it won't be completely unloaded from memory
+        getChunkProvider().addTicketAtLevel(SWM_TICKET, pos, 33, Unit.INSTANCE);
+
+        Consumer<Chunk> loadEntities = (nmsChunk) -> {
+
+            // Load tile entities
+            LOGGER.debug("Loading tile entities for chunk (" + pos.x + ", " + pos.z + ") on world " + slimeWorld.getName());
+            List<CompoundTag> tileEntities = chunk.getTileEntities();
+            int loadedEntities = 0;
+
+            if (tileEntities != null) {
+                for (CompoundTag tag : tileEntities) {
+                    Optional<String> type = tag.getStringValue("id");
+
+                    // Sometimes null tile entities are saved
+                    if (type.isPresent()) {
+                        IBlockData blockData = nmsChunk.getType(tag.getIntValue("x").get(),
+                                tag.getIntValue("y").get(), tag.getIntValue("z").get());
+                        TileEntity entity = TileEntity.create(blockData, (NBTTagCompound) Converter.convertTag(tag));
+
+                        if (entity != null) {
+                            nmsChunk.a(entity);
+                            loadedEntities++;
+                        }
+                    }
+                }
+            }
+
+            LOGGER.debug("Loaded " + loadedEntities + " tile entities for chunk (" + pos.x + ", " + pos.z + ") on world " + slimeWorld.getName());
+
+            // Load entities
+            LOGGER.debug("Loading entities for chunk (" + pos.x + ", " + pos.z + ") on world " + slimeWorld.getName());
+            List<CompoundTag> entities = chunk.getEntities();
+            loadedEntities = 0;
+
+            if (entities != null) {
+                for (CompoundTag tag : entities) {
+                    EntityTypes.a((NBTTagCompound) Converter.convertTag(tag), nmsChunk.world, (entity) -> {
+
+                        nmsChunk.a(entity);
+                        return entity;
+
+                    });
+
+                    nmsChunk.d(true);
+                    loadedEntities++;
+                }
+            }
+
+            LOGGER.debug("Loaded " + loadedEntities + " entities for chunk (" + pos.x + ", " + pos.z + ") on world " + slimeWorld.getName());
+
+        };
+
+        CompoundTag upgradeDataTag = ((CraftSlimeChunk) chunk).getUpgradeData();
+        Chunk nmsChunk = new Chunk(this, pos, biomeStorage, upgradeDataTag == null ? ChunkConverter.a : new ChunkConverter((NBTTagCompound)
+                Converter.convertTag(upgradeDataTag)), blockTickList, fluidTickList, 0L, sections, loadEntities);
+
+        // Height Maps
+        EnumSet<HeightMap.Type> heightMapTypes = nmsChunk.getChunkStatus().h();
+        CompoundMap heightMaps = chunk.getHeightMaps().getValue();
+        EnumSet<HeightMap.Type> unsetHeightMaps = EnumSet.noneOf(HeightMap.Type.class);
+
+        for (HeightMap.Type type : heightMapTypes) {
+            String name = type.getName();
+
+            if (heightMaps.containsKey(name)) {
+                LongArrayTag heightMap = (LongArrayTag) heightMaps.get(name);
+                nmsChunk.a(type, heightMap.getValue());
+            } else {
+                unsetHeightMaps.add(type);
+            }
+        }
+
+        HeightMap.a(nmsChunk, unsetHeightMaps);
+        LOGGER.debug("Loaded chunk (" + pos.x + ", " + pos.z + ") on world " + slimeWorld.getName());
+
+        return nmsChunk;
+    }
+
+    void saveChunk(Chunk chunk) {
+        SlimeChunk slimeChunk = slimeWorld.getChunk(chunk.getPos().x, chunk.getPos().z);
+
+        if (slimeChunk instanceof NMSSlimeChunk) { // In case somehow the chunk object changes (might happen for some reason)
+            ((NMSSlimeChunk) slimeChunk).setChunk(chunk);
+        } else {
+            slimeWorld.updateChunk(new NMSSlimeChunk(chunk));
+        }
+    }
+
+}

--- a/slimeworldmanager-nms-v1_16_R3/src/main/java/com/grinderwolf/swm/v1_16_R3/NMSSlimeChunk.java
+++ b/slimeworldmanager-nms-v1_16_R3/src/main/java/com/grinderwolf/swm/v1_16_R3/NMSSlimeChunk.java
@@ -1,0 +1,124 @@
+package com.grinderwolf.swm.v1_16_R3;
+
+import com.flowpowered.nbt.CompoundMap;
+import com.flowpowered.nbt.CompoundTag;
+import com.flowpowered.nbt.ListTag;
+import com.flowpowered.nbt.LongArrayTag;
+import com.grinderwolf.swm.api.utils.NibbleArray;
+import com.grinderwolf.swm.api.world.SlimeChunk;
+import com.grinderwolf.swm.api.world.SlimeChunkSection;
+import com.grinderwolf.swm.nms.CraftSlimeChunkSection;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import net.minecraft.server.v1_16_R3.*;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+@Data
+@AllArgsConstructor
+public class NMSSlimeChunk implements SlimeChunk {
+
+    private Chunk chunk;
+
+    @Override
+    public String getWorldName() {
+        return ((WorldDataServer) chunk.getWorld().worldData).getName();
+    }
+
+    @Override
+    public int getX() {
+        return chunk.getPos().x;
+    }
+
+    @Override
+    public int getZ() {
+        return chunk.getPos().z;
+    }
+
+    @Override
+    public SlimeChunkSection[] getSections() {
+        SlimeChunkSection[] sections = new SlimeChunkSection[16];
+        LightEngine lightEngine = chunk.world.getChunkProvider().getLightEngine();
+
+        for (int sectionId = 0; sectionId < chunk.getSections().length; sectionId++) {
+            ChunkSection section = chunk.getSections()[sectionId];
+
+            if (section != null) {
+                section.recalcBlockCounts();
+
+                if (!section.c()) { // If the section is empty, just ignore it to save space
+                    // Block Light Nibble Array
+                    NibbleArray blockLightArray = Converter.convertArray(lightEngine.a(EnumSkyBlock.BLOCK).a(SectionPosition.a(chunk.getPos(), sectionId)));
+
+                    // Sky light Nibble Array
+                    NibbleArray skyLightArray = Converter.convertArray(lightEngine.a(EnumSkyBlock.SKY).a(SectionPosition.a(chunk.getPos(), sectionId)));
+
+                    // Block Data
+                    DataPaletteBlock dataPaletteBlock = section.getBlocks();
+                    NBTTagCompound blocksCompound = new NBTTagCompound();
+                    dataPaletteBlock.a(blocksCompound, "Palette", "BlockStates");
+                    NBTTagList paletteList = blocksCompound.getList("Palette", 10);
+                    ListTag<CompoundTag> palette = (ListTag<CompoundTag>) Converter.convertTag("", paletteList);
+                    long[] blockStates = blocksCompound.getLongArray("BlockStates");
+
+                    sections[sectionId] = new CraftSlimeChunkSection(null, null, palette, blockStates, blockLightArray, skyLightArray);
+                }
+            }
+        }
+
+        return sections;
+    }
+
+    @Override
+    public CompoundTag getHeightMaps() {
+        // HeightMap
+        CompoundMap heightMaps = new CompoundMap();
+
+        for (Map.Entry<HeightMap.Type, HeightMap> entry : chunk.heightMap.entrySet()) {
+            HeightMap.Type type = entry.getKey();
+            HeightMap map = entry.getValue();
+
+            heightMaps.put(type.getName(), new LongArrayTag(type.getName(), map.a()));
+        }
+
+       return new CompoundTag("", heightMaps);
+    }
+
+    @Override
+    public int[] getBiomes() {
+        return chunk.getBiomeIndex().a();
+    }
+
+    @Override
+    public List<CompoundTag> getTileEntities() {
+        List<CompoundTag> tileEntities = new ArrayList<>();
+
+        for (TileEntity entity : chunk.getTileEntities().values()) {
+            NBTTagCompound entityNbt = new NBTTagCompound();
+            entity.save(entityNbt);
+            tileEntities.add((CompoundTag) Converter.convertTag("", entityNbt));
+        }
+
+        return tileEntities;
+    }
+
+    @Override
+    public List<CompoundTag> getEntities() {
+        List<CompoundTag> entities = new ArrayList<>();
+
+        for (int i = 0; i < chunk.getEntitySlices().length; i++) {
+            for (Entity entity : chunk.getEntitySlices()[i]) {
+                NBTTagCompound entityNbt = new NBTTagCompound();
+
+                if (entity.d(entityNbt)) {
+                    chunk.d(true);
+                    entities.add((CompoundTag) Converter.convertTag("", entityNbt));
+                }
+            }
+        }
+
+        return entities;
+    }
+}

--- a/slimeworldmanager-nms-v1_16_R3/src/main/java/com/grinderwolf/swm/v1_16_R3/v1_16_R3SlimeNMS.java
+++ b/slimeworldmanager-nms-v1_16_R3/src/main/java/com/grinderwolf/swm/v1_16_R3/v1_16_R3SlimeNMS.java
@@ -1,0 +1,224 @@
+package com.grinderwolf.swm.v1_16_R3;
+
+import com.flowpowered.nbt.CompoundTag;
+import com.grinderwolf.swm.api.world.SlimeWorld;
+import com.grinderwolf.swm.api.world.properties.SlimeProperties;
+import com.grinderwolf.swm.nms.CraftSlimeWorld;
+import com.grinderwolf.swm.nms.SlimeNMS;
+import com.mojang.serialization.Dynamic;
+import com.mojang.serialization.Lifecycle;
+import lombok.Getter;
+import net.minecraft.server.v1_16_R3.*;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.bukkit.Bukkit;
+import org.bukkit.World;
+import org.bukkit.craftbukkit.libs.org.apache.commons.io.FileUtils;
+import org.bukkit.craftbukkit.v1_16_R3.CraftWorld;
+import org.bukkit.craftbukkit.v1_16_R3.util.CraftMagicNumbers;
+import org.bukkit.event.world.WorldInitEvent;
+import org.bukkit.event.world.WorldLoadEvent;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.UUID;
+
+@Getter
+public class v1_16_R3SlimeNMS implements SlimeNMS {
+
+    private static final Logger LOGGER = LogManager.getLogger("SWM");
+    private static final File UNIVERSE_DIR;
+    public static Convertable CONVERTABLE;
+
+    static {
+        Path path;
+
+        try {
+            path = Files.createTempDirectory("swm-" + UUID.randomUUID().toString().substring(0, 5) + "-");
+        } catch (IOException ex) {
+            LOGGER.log(Level.FATAL, "Failed to create temp directory", ex);
+            path = null;
+            System.exit(1);
+        }
+
+        UNIVERSE_DIR = path.toFile();
+        CONVERTABLE = Convertable.a(path);
+
+        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+
+            try {
+                FileUtils.deleteDirectory(UNIVERSE_DIR);
+            } catch (IOException ex) {
+                LOGGER.log(Level.FATAL, "Failed to delete temp directory", ex);
+            }
+
+        }));
+    }
+
+    private final byte worldVersion = 0x06;
+
+    private boolean loadingDefaultWorlds = true; // If true, the addWorld method will not be skipped
+
+    private CustomWorldServer defaultWorld;
+    private CustomWorldServer defaultNetherWorld;
+    private CustomWorldServer defaultEndWorld;
+
+    public v1_16_R3SlimeNMS() {
+        try {
+            CraftCLSMBridge.initialize(this);
+        } catch (NoClassDefFoundError ex) {
+            LOGGER.error("Failed to find ClassModifier classes. Are you sure you installed it correctly?");
+            System.exit(1); // No ClassModifier, no party
+        }
+    }
+
+    @Override
+    public void setDefaultWorlds(SlimeWorld normalWorld, SlimeWorld netherWorld, SlimeWorld endWorld) {
+        if (normalWorld != null) {
+            defaultWorld = createDefaultWorld(normalWorld, WorldDimension.OVERWORLD, net.minecraft.server.v1_16_R3.World.OVERWORLD);
+        }
+
+        if (netherWorld != null) {
+            defaultNetherWorld = createDefaultWorld(netherWorld, WorldDimension.THE_NETHER, net.minecraft.server.v1_16_R3.World.THE_NETHER);
+        }
+
+        if (endWorld != null) {
+            defaultEndWorld = createDefaultWorld(endWorld, WorldDimension.THE_END, net.minecraft.server.v1_16_R3.World.THE_END);
+        }
+
+        loadingDefaultWorlds = false;
+    }
+
+    private CustomWorldServer createDefaultWorld(SlimeWorld world, ResourceKey<WorldDimension> dimensionKey,
+                                                 ResourceKey<net.minecraft.server.v1_16_R3.World> worldKey) {
+        WorldDataServer worldDataServer = createWorldData(world.getName(), world.getExtraData());
+
+        RegistryMaterials<WorldDimension> registryMaterials = worldDataServer.getGeneratorSettings().d();
+        WorldDimension worldDimension = registryMaterials.a(dimensionKey);
+        DimensionManager dimensionManager = worldDimension.b();
+        ChunkGenerator chunkGenerator = worldDimension.c();
+
+        World.Environment environment = getEnvironment(world);
+
+        if (dimensionKey == WorldDimension.OVERWORLD && environment != World.Environment.NORMAL) {
+            LOGGER.warn("The environment for the default world should always be 'NORMAL'.");
+        }
+
+        try {
+            return new CustomWorldServer((CraftSlimeWorld) world, worldDataServer,
+                    worldKey, dimensionKey, dimensionManager, chunkGenerator, environment);
+        } catch (IOException ex) {
+            throw new RuntimeException(ex); // TODO do something better with this?
+        }
+    }
+
+    @Override
+    public void generateWorld(SlimeWorld world) {
+        String worldName = world.getName();
+
+        if (Bukkit.getWorld(worldName) != null) {
+            throw new IllegalArgumentException("World " + worldName + " already exists! Maybe it's an outdated SlimeWorld object?");
+        }
+
+        WorldDataServer worldDataServer = createWorldData(world.getName(), world.getExtraData());
+        RegistryMaterials<WorldDimension> materials = worldDataServer.getGeneratorSettings().d();
+        WorldDimension worldDimension = materials.a(WorldDimension.OVERWORLD);
+        DimensionManager dimensionManager = worldDimension.b();
+        ChunkGenerator chunkGenerator = worldDimension.c();
+
+        ResourceKey<net.minecraft.server.v1_16_R3.World> worldKey = ResourceKey.a(IRegistry.L,
+                new MinecraftKey(worldName.toLowerCase(java.util.Locale.ENGLISH)));
+
+        World.Environment environment = getEnvironment(world);
+
+        CustomWorldServer server;
+
+        try {
+            server = new CustomWorldServer((CraftSlimeWorld) world, worldDataServer,
+                    worldKey, WorldDimension.OVERWORLD, dimensionManager, chunkGenerator, environment);
+        } catch (IOException ex) {
+            throw new RuntimeException(ex); // TODO do something better with this?
+        }
+
+        LOGGER.info("Loading world " + worldName);
+        long startTime = System.currentTimeMillis();
+
+        server.setReady(true);
+
+        MinecraftServer mcServer = MinecraftServer.getServer();
+        mcServer.initWorld(server, worldDataServer, mcServer.getSaveData(), worldDataServer.getGeneratorSettings());
+
+        mcServer.server.addWorld(server.getWorld());
+        mcServer.worldServer.put(worldKey, server);
+
+        Bukkit.getPluginManager().callEvent(new WorldInitEvent(server.getWorld()));
+        mcServer.loadSpawn(server.getChunkProvider().playerChunkMap.worldLoadListener, server);
+        Bukkit.getPluginManager().callEvent(new WorldLoadEvent(server.getWorld()));
+
+        LOGGER.info("World " + worldName + " loaded in " + (System.currentTimeMillis() - startTime) + "ms.");
+    }
+
+    private World.Environment getEnvironment(SlimeWorld world) {
+        return World.Environment.valueOf(world.getPropertyMap().getString(SlimeProperties.ENVIRONMENT).toUpperCase());
+    }
+
+    private WorldDataServer createWorldData(String worldName, CompoundTag extraData) {
+        WorldDataServer worldDataServer;
+        NBTTagCompound extraTag = (NBTTagCompound) Converter.convertTag(extraData);
+        MinecraftServer mcServer = MinecraftServer.getServer();
+
+        if (extraTag.hasKeyOfType("LevelData", CraftMagicNumbers.NBT.TAG_COMPOUND)) {
+            NBTTagCompound levelData = extraTag.getCompound("LevelData");
+            int dataVersion = levelData.hasKeyOfType("DataVersion", 99) ? levelData.getInt("DataVersion") : -1;
+            Dynamic<NBTBase> dynamic = mcServer.getDataFixer().update(DataFixTypes.LEVEL.a(),
+                    new Dynamic<>(DynamicOpsNBT.a, levelData), dataVersion, SharedConstants.getGameVersion()
+                            .getWorldVersion());
+            GeneratorSettings generatorSettings = GeneratorSettings.a(mcServer.getCustomRegistry());
+            Lifecycle lifecycle = Lifecycle.stable();
+            LevelVersion levelVersion = LevelVersion.a(dynamic);
+            WorldSettings worldSettings = WorldSettings.a(dynamic, mcServer.datapackconfiguration);
+
+            worldDataServer = WorldDataServer.a(dynamic, mcServer.getDataFixer(), dataVersion, null,
+                    worldSettings, levelVersion, generatorSettings, lifecycle);
+        } else {
+            EnumDifficulty difficulty = ((DedicatedServer) mcServer).getDedicatedServerProperties().difficulty;
+            EnumGamemode defaultGamemode = ((DedicatedServer) mcServer).getDedicatedServerProperties().gamemode;
+            WorldSettings worldSettings = new WorldSettings(worldName, defaultGamemode, false,
+                    difficulty, false, new GameRules(), mcServer.datapackconfiguration);
+            worldDataServer = new WorldDataServer(worldSettings, ((DedicatedServer) mcServer)
+                    .getDedicatedServerProperties().generatorSettings, Lifecycle.stable());
+        }
+
+        worldDataServer.checkName(worldName);
+        worldDataServer.a(mcServer.getServerModName(), mcServer.getModded().isPresent());
+        worldDataServer.c(true);
+
+        return worldDataServer;
+    }
+
+    @Override
+    public SlimeWorld getSlimeWorld(World world) {
+        CraftWorld craftWorld = (CraftWorld) world;
+
+        if (!(craftWorld.getHandle() instanceof CustomWorldServer)) {
+            return null;
+        }
+
+        CustomWorldServer worldServer = (CustomWorldServer) craftWorld.getHandle();
+        return worldServer.getSlimeWorld();
+    }
+
+    @Override
+    public CompoundTag convertChunk(CompoundTag tag) {
+        NBTTagCompound nmsTag = (NBTTagCompound) Converter.convertTag(tag);
+        int version = nmsTag.getInt("DataVersion");
+
+        NBTTagCompound newNmsTag = GameProfileSerializer.a(DataConverterRegistry.a(), DataFixTypes.CHUNK, nmsTag, version);
+
+        return (CompoundTag) Converter.convertTag("", newNmsTag);
+    }
+
+}

--- a/slimeworldmanager-nms-v1_8_R3/pom.xml
+++ b/slimeworldmanager-nms-v1_8_R3/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>slimeworldmanager</artifactId>
         <groupId>com.grinderwolf</groupId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <properties>

--- a/slimeworldmanager-nms-v1_9_R1/pom.xml
+++ b/slimeworldmanager-nms-v1_9_R1/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>slimeworldmanager</artifactId>
         <groupId>com.grinderwolf</groupId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <properties>

--- a/slimeworldmanager-nms-v1_9_R2/pom.xml
+++ b/slimeworldmanager-nms-v1_9_R2/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>slimeworldmanager</artifactId>
         <groupId>com.grinderwolf</groupId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <properties>

--- a/slimeworldmanager-plugin/pom.xml
+++ b/slimeworldmanager-plugin/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>slimeworldmanager</artifactId>
         <groupId>com.grinderwolf</groupId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>slimeworldmanager-plugin</artifactId>
@@ -115,6 +115,12 @@
             <groupId>org.bstats</groupId>
             <artifactId>bstats-bukkit</artifactId>
             <version>1.5</version>
+        </dependency>
+        <dependency>
+            <groupId>com.grinderwolf</groupId>
+            <artifactId>slimeworldmanager-nms-v1_16_R3</artifactId>
+            <version>2.3.1-SNAPSHOT</version>
+            <scope>compile</scope>
         </dependency>
     </dependencies>
     <build>

--- a/slimeworldmanager-plugin/src/main/java/com/grinderwolf/swm/plugin/SWMPlugin.java
+++ b/slimeworldmanager-plugin/src/main/java/com/grinderwolf/swm/plugin/SWMPlugin.java
@@ -31,6 +31,7 @@ import com.grinderwolf.swm.plugin.upgrade.WorldUpgrader;
 import com.grinderwolf.swm.plugin.world.WorldUnlocker;
 import com.grinderwolf.swm.plugin.world.importer.WorldImporter;
 import com.grinderwolf.swm.v1_16_R2.v1_16_R2SlimeNMS;
+import com.grinderwolf.swm.v1_16_R3.v1_16_R3SlimeNMS;
 import lombok.Getter;
 import ninja.leaping.configurate.objectmapping.ObjectMappingException;
 import org.bstats.bukkit.Metrics;
@@ -185,6 +186,8 @@ public class SWMPlugin extends JavaPlugin implements SlimePlugin {
                 return new v1_15_R1SlimeNMS();
             case "v1_16_R2":
                 return new v1_16_R2SlimeNMS();
+            case "v1_16_R3":
+                return new v1_16_R3SlimeNMS();
             default:
                 throw new InvalidVersionException(nmsVersion);
         }


### PR DESCRIPTION
I added 1.16 Support for 1.16.4/5.

The only real difference was a mapping change in the DeticatedServer NMS class.
I tested the Plugin and everything I tested worked. I loaded a big schematic with FAWE in my SWM world and saved, restarted and everything was there. Chests Save(With Items and Items with NBT. I tested it with full chests in chests ^^), Mobs Save, Blocks with Entity NBTs save(I tested a nest with bees that have different or no nametags) and that's pretty much all I tested.

I did not test it on 1.16.5 though. It worked fine on 1.16.4(it is 1.16_R3) and I used the 1.16.5 import of paper, so it should also work completely fine on 1.16.5. 

I really hope that this will be merged soon, and we will see a full SWM update for 1.16 soon. ;)
